### PR TITLE
Add backend and full-stack names in ROLES.md

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -6,8 +6,8 @@
   - Michal 
   - Alicia
 - Backend
-  - (null)
-  - (null)
+  - Lin
+  - Jonathan
 - Full Stack
   - Grayson
-  - (null)
+  - Hannah


### PR DESCRIPTION
Replace placeholder '(null)' entries in ROLES.md: add Lin and Jonathan under Backend and add Hannah under Full Stack. This updates the project roles list with actual team members.