### PR TITLE
Add Team 2 meeting notes for Mar 10 & Mar 17

### DIFF
--- a/meetingNotes/3.10.26.md
+++ b/meetingNotes/3.10.26.md
@@ -1,0 +1,31 @@
+## Mar 10, 2026 | [Team 2 Meeting](https://www.google.com/calendar/event?eid=ZDJ0NXNiamxiNnRkZDdmZWl0NTA0YnF2aG9fMjAyNjAzMTFUMDAwMDAwWiBnbWphY2tzb25AdWFsci5lZHU)
+
+Attendees: [Alicia Johansen](mailto:aracosta@ualr.edu) [Grayson Jackson](mailto:gmjackson@ualr.edu) [Jonathan Armstrong](mailto:jaarmstron@ualr.edu) [Lindsay Oldfield](mailto:leoldfield@ualr.edu) [Michal Griffith](mailto:mlgriffith@ualr.edu)
+
+Notes
+
+* Stand‑up Highlights  
+  * Grayson – Built the dashboard prototype and collaborated with Lin on a sample database.  
+  * Lin – Designed the concept database, created the actual database, and plans to import workout data from CSV.  
+  * Alicia – Explored dashboard concepts and is adjusting the login method.  
+  * Jonathan – Drafted workout descriptions, is revising them for accuracy, and focusing on form; no current blockers.  
+* Layout vs. Integration  
+  * Decision to split focus between layout work and integration tasks.  
+* User Stories  
+  * Detailed Card – Michal & Alicia.  
+  * Create Dummy Data – Lin.  
+  * Login Screen Integration – Grayson.  
+  * Health Data Calculations – Jonathan.
+
+Action items
+
+- [x] ~~Review progress form last meeting and standup~~  
+- [x] ~~Daily standup~~  
+- [x] ~~Future Steps: Layout or integration?~~  
+- [x] ~~Establish new user stories~~  
+      - [x] ~~Every story includes acceptance criteria~~   
+      - [x] ~~Each story is assigned to one person~~   
+      - [x] ~~Each story is small enough for one week~~   
+      - [x] ~~Each story will have its own branch~~  
+      - [x] ~~Each listed as an issue~~  
+- [x] ~~Scrum master handoff~~

--- a/meetingNotes/3.17.26.md
+++ b/meetingNotes/3.17.26.md
@@ -1,0 +1,26 @@
+Mar 17, 2026 | Team 2 Meeting
+Attendees: Alicia Johansen Grayson Jackson Jonathan Armstrong Khangai Altangerel Lindsay Oldfield Michal Griffith
+
+Notes
+Stand‑up Highlights
+Grayson – Completed a basic PIN‑login UI and logic (Jetpack Compose). Dashboard prototype is ready for screen‑share; will demo on a physical device next.
+Lin – Designed the local database schema (users, workouts, logs, journal, preferences). Added pre‑populated workout data from a CSV raw file; first login will not recreate data.
+Alicia – Refactored the home‑page UI in Figma, added optional custom colours, and discussed navigation/tabs.  Also reviewed the login flow with the backend.
+Jonathan – Updated workout descriptions, added a “difficulty” field for both workouts and exercises, and is building BMI/ macro calculation logic.  Started drafting health‑calculation equations for the app.
+Michal – Working on the settings tab (emails, gym‑hours, etc.) and on the workout‑tracker UI (progress bar, log button).  Ensured the settings button routes to the settings screen.
+Backend / Database
+Tables: users, workouts, workout_logs, journal_entries, preferences.
+Pre‑populated data is loaded once on app start; subsequent logins just read the data.
+Added “difficulty” column to both workouts and exercises; plan to calculate an average difficulty per workout.
+Will separate mental‑health data into its own table to avoid over‑loading the biometric table.
+Frontend / UI
+Dashboard layout is a “skeletal” screen – key health metrics only (steps, heart‑rate, sleep).
+Login page UI (Jetpack Compose) is complete and aligned with design.
+Settings screen and tab navigation now functional.
+
+Action items
+Review progress from last meeting and standup
+Celebrate being the example
+Daily standup
+New user stories (database)
+Mental health tracking 


### PR DESCRIPTION
Add meeting notes for Team 2 meetings on 2026-03-10 and 2026-03-17. Documents include attendees, stand-up highlights, action items, and user-story assignments. Mar 10 notes assign owners for detailed card, dummy data, login integration, and health-data calculations and record the decision to split layout vs integration. Mar 17 notes capture progress: PIN-login UI (Jetpack Compose), local DB schema with pre-populated CSV data, added "difficulty" to workouts/exercises, dashboard and settings UI updates, and next action items (new user stories, mental-health tracking).