### PR TITLE
Add Team 2 meeting notes (2026-03-31)

### DIFF
--- a/meetingNotes/3.31.26.md
+++ b/meetingNotes/3.31.26.md
@@ -1,0 +1,69 @@
+## Mar 31, 2026 | [Team 2 Meeting](https://www.google.com/calendar/event?eid=ZDJ0NXNiamxiNnRkZDdmZWl0NTA0YnF2aG9fMjAyNjA0MDFUMDAwMDAwWiBnbWphY2tzb25AdWFsci5lZHU)
+
+Attendees: [Alicia Johansen](mailto:aracosta@ualr.edu) [Grayson Jackson](mailto:gmjackson@ualr.edu) [Jonathan Armstrong](mailto:jaarmstron@ualr.edu) [Khangai Altangerel](mailto:kaltangerel@ualr.edu) [Lindsay Oldfield](mailto:leoldfield@ualr.edu) [Michal Griffith](mailto:mlgriffith@ualr.edu)
+
+Notes
+
+* Standup  
+  * Lin  
+    * Has made mental health database and Dao  
+    * Integrated into the simple one that Grayson made to make more robust  
+    * Planning on seeing what the group thinks is the next best move  
+    * No blockers currently  
+  * Grayson  
+    * Integrated onboarding screen, dashboard and settings screens  
+    * Added a dark mode  
+    * Made the ability to clear pin  
+    * Added gym hours to dashboard  
+    * Overhauled dashboard design using what Alicia gave  
+    * Uses calculations Jonathan gave  
+    * Wants to work on macro screen integration and possibly workout screen once given them  
+  * Jonathan  
+    * Since 2 weeks ago, took off for spring break  
+    * Gathered and created a bunch of health calculations such as protein goal and bmi, bmr  
+    * Also created unit conversions for imperial and metric  
+    * Looking for more to do  
+  * Alicia  
+    * Since last meeting, worked on ability to add workout button so users can choose what they want to target and create workouts  
+    * Wants to add picture of each muscle so people can choose easier  
+    * Looking into mental health but needs to consult with backend  
+  * Michal  
+    * Since last meeting  
+    * Created detailed macro screen card and worked on settings  
+    * Will continue to add things like nutrient adding  
+* What Next?  
+  * Wrap up what we got  
+  * Workout screens gotta be the next goals  
+  * Workout video  
+    * Video source  
+  * Custom workout builder  
+  * Dynamic workout screen  
+* Google Fit Integration  
+  * Hold off for now  
+* User Stories This Week  
+  * Michal  
+    * Detailed macros  
+  * Grayson  
+    * Mental Health Integration  
+  * Lin  
+    * Custom Workouts  
+  * Jonathan  
+    * Video Integration (and sourcing them)  
+  * Alicia  
+    * Workout Screen  
+* Hand Off Scrum Master  
+  * Jonathan
+
+Action items
+
+- [x] ~~Review progress from last meeting and standup~~  
+- [x] ~~Daily standup~~  
+- [x] ~~What next?~~  
+- [x] ~~Google fit Integration?~~  
+- [x] ~~Establish new user stories~~  
+      - [x] ~~Every story includes acceptance criteria~~   
+      - [x] ~~Each story is assigned to one person~~   
+      - [x] ~~Each story is small enough for one week~~   
+      - [x] ~~Each story will have its own branch~~  
+      - [x] ~~Each listed as an issue~~  
+- [x] ~~Hand off scrum master~~


### PR DESCRIPTION
Add meeting notes for Team 2 on 2026-03-31 (meetingNotes/3.31.26.md). Includes attendee list, standup updates from each member, planned next steps (workout screens, custom builder, video integration), decision to hold off Google Fit integration, assigned user stories, and completed action items including scrum master handoff to Jonathan.