### PR TITLE
Use Flow for theme, default to light; UI updates

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/MainActivity.kt
+++ b/app/src/main/java/com/team2/studentfitness/MainActivity.kt
@@ -50,13 +50,9 @@ class MainActivity : ComponentActivity() {
             val database = (application as DatabaseCreation).database
             val settingsDao = database.settingsDao()
             
-            var isDarkMode by remember { mutableStateOf(false) }
-            
-            LaunchedEffect(Unit) {
-                settingsDao.getAll().lastOrNull()?.let {
-                    isDarkMode = it.theme == 1
-                }
-            }
+            // Use Flow to observe theme changes in real-time across the app
+            val latestSettings by settingsDao.getLatestFlow().collectAsState(initial = null)
+            val isDarkMode = latestSettings?.theme == 1
 
             StudentFitnessTheme(darkTheme = isDarkMode) {
                 val navController = rememberNavController()
@@ -123,8 +119,7 @@ class MainActivity : ComponentActivity() {
                                     navController.navigate(nextDest) {
                                         popUpTo(AppRoutes.Dashboard) { inclusive = true }
                                     }
-                                },
-                                onThemeChanged = { isDarkMode = it }
+                                }
                             )
                         }
                         composable(

--- a/app/src/main/java/com/team2/studentfitness/database/SettingsDao.kt
+++ b/app/src/main/java/com/team2/studentfitness/database/SettingsDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface SettingsDao {
@@ -16,6 +17,9 @@ interface SettingsDao {
 
     @Query("SELECT * FROM usersettings ORDER BY uid DESC LIMIT 1")
     suspend fun getLatest(): UserSettings?
+
+    @Query("SELECT * FROM usersettings ORDER BY uid DESC LIMIT 1")
+    fun getLatestFlow(): Flow<UserSettings?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(userSettings: UserSettings)

--- a/app/src/main/java/com/team2/studentfitness/database/UserSettings.kt
+++ b/app/src/main/java/com/team2/studentfitness/database/UserSettings.kt
@@ -13,7 +13,7 @@ data class UserSettings (
     val name: String,
     @ColumnInfo(name = "notifsOn")
     val notifsOn: Boolean,
-    @ColumnInfo(name = "theme", defaultValue = "1")
+    @ColumnInfo(name = "theme", defaultValue = "0")
     val theme: Int,
     @ColumnInfo(name = "homeGym")
     val homeGym: Int,

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/Dashboard.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/Dashboard.kt
@@ -1,14 +1,17 @@
 package com.team2.studentfitness.ui.screens
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.MonitorWeight
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Settings
@@ -35,7 +38,9 @@ import com.team2.studentfitness.ui.navigation.AppRoutes
 import com.team2.studentfitness.ui.theme.*
 import com.team2.studentfitness.viewmodels.HealthCalculations
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 
 @Composable
@@ -57,6 +62,8 @@ fun Dashboard(navController: NavController) {
     // Mental Health State
     var selectedMood by remember { mutableStateOf("") }
     var reflectionText by remember { mutableStateOf("") }
+    var mentalHealthLogs by remember { mutableStateOf<List<MentalHealth>>(emptyList()) }
+    var showLogs by remember { mutableStateOf(false) }
 
     val greeting = when (Calendar.getInstance().get(Calendar.HOUR_OF_DAY)) {
         in 0..11 -> "Good Morning,"
@@ -71,10 +78,14 @@ fun Dashboard(navController: NavController) {
                 userName = it.name
             }
             latestHealthData = healthDao.getLatest()
+            mentalHealthLogs = mentalHealthDao.getAll()
         } catch (_: Exception) {
             // Suppress unused exception warning
         }
     }
+
+    val isDark = userSettings?.theme == 1
+    val textColor = if (isDark) Color.White else Color.Black
 
     Box(
         modifier = Modifier
@@ -92,7 +103,6 @@ fun Dashboard(navController: NavController) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.Top
             ) {
-                val textColor = if (userSettings?.theme == 1) Color.White else Color.Black
                 Column {
                     Text(
                         text = greeting,
@@ -131,18 +141,20 @@ fun Dashboard(navController: NavController) {
                     .fillMaxWidth()
                     .height(56.dp)
                     .clip(RoundedCornerShape(16.dp))
-                    .background(if (userSettings?.theme == 1) Color.DarkGray else Color.White),
+                    .background(if (isDark) Color.DarkGray else Color.White),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 TabButton(
                     text = "Workout",
                     isSelected = selectedTab == "Workout",
+                    isDark = isDark,
                     modifier = Modifier.weight(1f),
                     onClick = { selectedTab = "Workout" }
                 )
                 TabButton(
                     text = "Mental Health",
                     isSelected = selectedTab == "Mental Health",
+                    isDark = isDark,
                     modifier = Modifier.weight(1f),
                     onClick = { selectedTab = "Mental Health" }
                 )
@@ -160,6 +172,9 @@ fun Dashboard(navController: NavController) {
                     reflectionText = reflectionText,
                     onReflectionChanged = { reflectionText = it },
                     userSettings = userSettings,
+                    logs = mentalHealthLogs,
+                    showLogs = showLogs,
+                    onToggleLogs = { showLogs = !showLogs },
                     onSave = {
                         scope.launch {
                             mentalHealthDao.insert(
@@ -167,6 +182,7 @@ fun Dashboard(navController: NavController) {
                             )
                             reflectionText = ""
                             selectedMood = ""
+                            mentalHealthLogs = mentalHealthDao.getAll()
                         }
                     }
                 )
@@ -176,7 +192,7 @@ fun Dashboard(navController: NavController) {
 }
 
 @Composable
-fun TabButton(text: String, isSelected: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun TabButton(text: String, isSelected: Boolean, isDark: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
     Box(
         modifier = modifier
             .fillMaxHeight()
@@ -188,7 +204,7 @@ fun TabButton(text: String, isSelected: Boolean, modifier: Modifier = Modifier, 
     ) {
         Text(
             text = text,
-            color = if (isSelected) Color.White else (if (isSystemInDarkTheme()) Color.White else Color.Black),
+            color = if (isSelected) Color.White else (if (isDark) Color.White else Color.Black),
             fontWeight = FontWeight.Bold
         )
     }
@@ -434,13 +450,20 @@ fun MentalHealthTabContent(
     reflectionText: String,
     onReflectionChanged: (String) -> Unit,
     userSettings: UserSettings?,
+    logs: List<MentalHealth>,
+    showLogs: Boolean,
+    onToggleLogs: () -> Unit,
     onSave: () -> Unit
 ) {
     val isDark = userSettings?.theme == 1
     val textColor = if (isDark) Color.White else Color.Black
     val cardBg = if (isDark) Color(0xFF1E1E1E) else Color(0xFFFAF3F3)
 
-    Column(modifier = Modifier.fillMaxWidth()) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+    ) {
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(24.dp),
@@ -512,12 +535,77 @@ fun MentalHealthTabContent(
                 Button(
                     onClick = onSave,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB099FF)),
+                    colors = ButtonDefaults.buttonColors(containerColor = if (isDark) Teal else Color(0xFFB099FF)),
                     shape = RoundedCornerShape(12.dp)
                 ) {
                     Text("Save Note", color = Color.White, fontWeight = FontWeight.Bold)
                 }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                TextButton(
+                    onClick = onToggleLogs,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.History,
+                            contentDescription = null,
+                            tint = if (isDark) Teal else Color(0xFFB099FF)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (showLogs) "Hide Logs" else "Show Logs",
+                            color = if (isDark) Teal else Color(0xFFB099FF),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
             }
+        }
+
+        AnimatedVisibility(visible = showLogs) {
+            Column(modifier = Modifier.padding(top = 16.dp)) {
+                logs.forEach { log ->
+                    JournalEntryItem(log, cardBg, textColor)
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+fun JournalEntryItem(log: MentalHealth, cardBg: Color, textColor: Color) {
+    val dateFormat = SimpleDateFormat("MMM dd, yyyy - hh:mm a", Locale.getDefault())
+    val dateString = dateFormat.format(Date(log.timestamp))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = cardBg)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = log.mood, fontSize = 24.sp)
+                Text(
+                    text = dateString,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = textColor.copy(alpha = 0.6f)
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = log.reflection,
+                style = MaterialTheme.typography.bodyMedium,
+                color = textColor
+            )
         }
     }
 }

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/OnboardingScreen.kt
@@ -1,5 +1,6 @@
 package com.team2.studentfitness.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -9,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
@@ -33,114 +35,171 @@ fun OnboardingScreen(
 
     val scrollState = rememberScrollState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        Text("Welcome! Let's get started.", style = MaterialTheme.typography.headlineMedium)
-        
-        OutlinedTextField(
-            value = name,
-            onValueChange = { name = it },
-            label = { Text("Name") },
-            modifier = Modifier.fillMaxWidth()
-        )
+    // Explicitly set background to white for readability
+    Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                "Welcome! Let's get started.", 
+                style = MaterialTheme.typography.headlineMedium,
+                color = Color.Black
+            )
+            
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Gray
+                )
+            )
 
-        Text("Unit Preference", style = MaterialTheme.typography.titleMedium)
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            RadioButton(selected = isMetric, onClick = { isMetric = true })
-            Text("Metric (kg, cm)")
-            Spacer(modifier = Modifier.width(16.dp))
-            RadioButton(selected = !isMetric, onClick = { isMetric = false })
-            Text("Imperial (lb, in)")
-        }
+            Text("Unit Preference", style = MaterialTheme.typography.titleMedium, color = Color.Black)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RadioButton(
+                    selected = isMetric, 
+                    onClick = { isMetric = true },
+                    colors = RadioButtonDefaults.colors(selectedColor = Color.Black)
+                )
+                Text("Metric (kg, cm)", color = Color.Black)
+                Spacer(modifier = Modifier.width(16.dp))
+                RadioButton(
+                    selected = !isMetric, 
+                    onClick = { isMetric = false },
+                    colors = RadioButtonDefaults.colors(selectedColor = Color.Black)
+                )
+                Text("Imperial (lb, in)", color = Color.Black)
+            }
 
-        Text("Personal Info", style = MaterialTheme.typography.titleMedium)
+            Text("Personal Info", style = MaterialTheme.typography.titleMedium, color = Color.Black)
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            RadioButton(selected = selectedSex == HealthCalculations.Sex.MALE, onClick = { selectedSex = HealthCalculations.Sex.MALE })
-            Text("Male")
-            Spacer(modifier = Modifier.width(16.dp))
-            RadioButton(selected = selectedSex == HealthCalculations.Sex.FEMALE, onClick = { selectedSex = HealthCalculations.Sex.FEMALE })
-            Text("Female")
-        }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RadioButton(
+                    selected = selectedSex == HealthCalculations.Sex.MALE, 
+                    onClick = { selectedSex = HealthCalculations.Sex.MALE },
+                    colors = RadioButtonDefaults.colors(selectedColor = Color.Black)
+                )
+                Text("Male", color = Color.Black)
+                Spacer(modifier = Modifier.width(16.dp))
+                RadioButton(
+                    selected = selectedSex == HealthCalculations.Sex.FEMALE, 
+                    onClick = { selectedSex = HealthCalculations.Sex.FEMALE },
+                    colors = RadioButtonDefaults.colors(selectedColor = Color.Black)
+                )
+                Text("Female", color = Color.Black)
+            }
 
-        OutlinedTextField(
-            value = age,
-            onValueChange = { age = it },
-            label = { Text("Age") },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
+            OutlinedTextField(
+                value = age,
+                onValueChange = { age = it },
+                label = { Text("Age") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black
+                )
+            )
 
-        OutlinedTextField(
-            value = weight,
-            onValueChange = { weight = it },
-            label = { Text(if (isMetric) "Weight (kg)" else "Weight (lb)") },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth()
-        )
+            OutlinedTextField(
+                value = weight,
+                onValueChange = { weight = it },
+                label = { Text(if (isMetric) "Weight (kg)" else "Weight (lb)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black
+                )
+            )
 
-        OutlinedTextField(
-            value = height,
-            onValueChange = { height = it },
-            label = { Text(if (isMetric) "Height (cm)" else "Height (in)") },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth()
-        )
+            OutlinedTextField(
+                value = height,
+                onValueChange = { height = it },
+                label = { Text(if (isMetric) "Height (cm)" else "Height (in)") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black
+                )
+            )
 
-        Text("Activity Level", style = MaterialTheme.typography.titleMedium)
-        HealthCalculations.ActivityLevel.entries.forEach { level ->
+            Text("Activity Level", style = MaterialTheme.typography.titleMedium, color = Color.Black)
+            HealthCalculations.ActivityLevel.entries.forEach { level ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().clickable { selectedActivityLevel = level }
+                ) {
+                    RadioButton(
+                        selected = selectedActivityLevel == level, 
+                        onClick = { selectedActivityLevel = level },
+                        colors = RadioButtonDefaults.colors(selectedColor = Color.Black)
+                    )
+                    Text(
+                        level.name.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() },
+                        color = Color.Black
+                    )
+                }
+            }
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth().clickable { selectedActivityLevel = level }
-            ) {
-                RadioButton(selected = selectedActivityLevel == level, onClick = { selectedActivityLevel = level })
-                Text(level.name.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() })
-            }
-        }
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Checkbox(checked = setPin, onCheckedChange = { setPin = it })
-            Text("Set up a PIN for future logins?")
-        }
-
-        if (setPin) {
-            OutlinedTextField(
-                value = pin,
-                onValueChange = { pin = it },
-                label = { Text("PIN (Numbers only)") },
-                visualTransformation = PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth()
-            )
-        }
-
-        Button(
-            onClick = {
-                viewModel.completeOnboarding(
-                    name = name,
-                    age = age.toIntOrNull() ?: 0,
-                    weight = weight.toFloatOrNull() ?: 0f,
-                    height = height.toFloatOrNull() ?: 0f,
-                    pin = if (setPin) pin.toIntOrNull() else null,
-                    isMetric = isMetric,
-                    sex = selectedSex.name,
-                    activityLevel = selectedActivityLevel.name,
-                    onComplete = onOnboardingComplete
+            ) {
+                Checkbox(
+                    checked = setPin, 
+                    onCheckedChange = { setPin = it },
+                    colors = CheckboxDefaults.colors(checkedColor = Color.Black)
                 )
-            },
-            modifier = Modifier.fillMaxWidth(),
-            enabled = name.isNotBlank() && age.isNotBlank() && weight.isNotBlank() && height.isNotBlank()
-        ) {
-            Text("Complete Onboarding")
+                Text("Set up a PIN for future logins?", color = Color.Black)
+            }
+
+            if (setPin) {
+                OutlinedTextField(
+                    value = pin,
+                    onValueChange = { pin = it },
+                    label = { Text("PIN (Numbers only)") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black
+                    )
+                )
+            }
+
+            Button(
+                onClick = {
+                    viewModel.completeOnboarding(
+                        name = name,
+                        age = age.toIntOrNull() ?: 0,
+                        weight = weight.toFloatOrNull() ?: 0f,
+                        height = height.toFloatOrNull() ?: 0f,
+                        pin = if (setPin) pin.toIntOrNull() else null,
+                        isMetric = isMetric,
+                        sex = selectedSex.name,
+                        activityLevel = selectedActivityLevel.name,
+                        onComplete = onOnboardingComplete
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = name.isNotBlank() && age.isNotBlank() && weight.isNotBlank() && height.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Black, contentColor = Color.White)
+            ) {
+                Text("Complete Onboarding")
+            }
         }
     }
 }

--- a/app/src/main/java/com/team2/studentfitness/ui/theme/Theme.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/theme/Theme.kt
@@ -22,16 +22,22 @@ private val DarkColorScheme = darkColorScheme(
     tertiary = Mint,
     background = Color.Black,
     surface = Color(0xFF121212),
+    surfaceVariant = Color(0xFF1E1E1E), // Dark card color
+    onSurfaceVariant = Color.White,
     onPrimary = Color.White,
-    onSecondary = Color.White
+    onSecondary = Color.White,
+    onBackground = Color.White,
+    onSurface = Color.White
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Teal,
     secondary = Orange,
     tertiary = Mint,
-    background = Teal, // Restore original teal background for light mode
+    background = Teal, // Original teal background
     surface = Color.White,
+    surfaceVariant = Color(0xFFFAF3F3), // Light creamy card color
+    onSurfaceVariant = Color.Black,
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onBackground = Color.Black,
@@ -60,7 +66,7 @@ fun StudentFitnessTheme(
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 

--- a/app/src/main/java/com/team2/studentfitness/viewmodels/OnboardingViewModel.kt
+++ b/app/src/main/java/com/team2/studentfitness/viewmodels/OnboardingViewModel.kt
@@ -52,12 +52,12 @@ class OnboardingViewModel(application: Application, private val securePinManager
             )
             appDatabase.healthDao().insert(healthData)
 
-            // 3. Store User Settings
+            // 3. Store User Settings - Default theme to 0 (Light Mode)
             val userSettings = UserSettings(
                 uid = uid,
                 name = name,
                 notifsOn = true,
-                theme = 1,
+                theme = 0,
                 homeGym = 0,
                 loginCount = 1,
                 isMetric = isMetric,


### PR DESCRIPTION
Replace one-off theme state with a Room Flow: add SettingsDao.getLatestFlow() and collect it in MainActivity so theme changes propagate in real-time. Change default theme to light (theme = 0) in UserSettings and OnboardingViewModel. Adjust theme color schemes and status bar appearance handling for clearer dark/light contrast. Update Dashboard UI to use the reactive theme, add mental health logs (show/hide, JournalEntryItem, AnimatedVisibility), and pass isDark into tab styling. Revamp OnboardingScreen visuals for consistent readability (explicit background/text colors, updated radio/checkbox styles and input colors), and style the onboarding button. Overall these changes improve theme reactivity, default to light mode, and enhance UI/UX for onboarding and mental health features.