### PR TITLE
Fix for Unread local variable

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
@@ -38,7 +38,6 @@ fun LoginScreen(
     val isDark = isSystemInDarkTheme()
     val bgColor = MaterialTheme.colorScheme.background
     val accentColor = MaterialTheme.colorScheme.secondary
-    val textColor = if (isDark) Color.White else Color.Black
 
     Box(
         modifier = modifier

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
@@ -39,7 +39,6 @@ fun LoginScreen(
     val bgColor = MaterialTheme.colorScheme.background
     val accentColor = MaterialTheme.colorScheme.secondary
     val textColor = if (isDark) Color.White else Color.Black
-    val secondaryTextColor = if (isDark) Color.LightGray else Color.White // Original subtitle was white on teal
 
     Box(
         modifier = modifier


### PR DESCRIPTION
In general, to fix a "local variable is never read" warning, you either remove the unused variable or start using it where appropriate. Since we must avoid changing behavior, the safest option is to delete the unused declaration, as it currently has no effect on runtime behavior.

The best fix here is to remove the line defining `secondaryTextColor` from `LoginScreen` because nothing in the provided code uses it. This does not affect any visible behavior, as the value is never read. No additional imports, methods, or definitions are required; we just delete the unused `val`.

Concretely, in `app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt`, delete line 42:

```kt
val secondaryTextColor = if (isDark) Color.LightGray else Color.White // Original subtitle was white on teal
```

Leave the surrounding declarations (`isDark`, `bgColor`, `accentColor`, `textColor`) untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._