### PR TITLE
Fix for Unread local variable

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
@@ -38,7 +38,6 @@ fun LoginScreen(
     val isDark = isSystemInDarkTheme()
     val bgColor = MaterialTheme.colorScheme.background
     val accentColor = MaterialTheme.colorScheme.secondary
-    val textColor = if (isDark) Color.White else Color.Black
     val secondaryTextColor = if (isDark) Color.LightGray else Color.White // Original subtitle was white on teal
 
     Box(


### PR DESCRIPTION
To fix the problem, we should remove the unused local variable `textColor`. This eliminates dead code and matches the intent of the CodeQL rule without changing existing functionality, since the variable is not referenced anywhere.

Concretely, in `app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt`, within the `LoginScreen` composable, delete the line declaring `textColor`:
```kt
val textColor = if (isDark) Color.White else Color.Black
```
No additional imports, methods, or definitions are needed, and no other lines must be changed. The remaining color variables (`bgColor`, `accentColor`, `secondaryTextColor`) remain as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._