### PR TITLE
Add Team 2 meeting notes (Apr 7, 2026)

### DIFF
--- a/meetingNotes/4.7.26.md
+++ b/meetingNotes/4.7.26.md
@@ -1,0 +1,30 @@
+## Apr 7, 2026 | [Team 2 Meeting](https://www.google.com/calendar/event?eid=ZDJ0NXNiamxiNnRkZDdmZWl0NTA0YnF2aG9fMjAyNjA0MDhUMDAwMDAwWiBnbWphY2tzb25AdWFsci5lZHU)
+
+Attendees: [Alicia Johansen](mailto:aracosta@ualr.edu) [Grayson Jackson](mailto:gmjackson@ualr.edu) [Jonathan Armstrong](mailto:jaarmstron@ualr.edu) [Khangai Altangerel](mailto:kaltangerel@ualr.edu) [Lindsay Oldfield](mailto:leoldfield@ualr.edu) 
+
+Notes
+
+* Standup  
+  * Grayson:   
+    * Completed UI onboarding color fixes. Currently implementing the mental health screen and resolving light mode issues.  
+  * Jonathan:   
+    * Focused on backend logic for video embedding, encountering some technical issues requiring further investigation.  
+  * Lin:   
+    * Conducted research into video integration aspects and potential video sources. Has explored front-end implementation details, but hasn’t yet identified a suitable video source selection.  
+  * Alicia:   
+    * Addressing system instability and developing workout screen layouts. The primary impediment is system-related issues.  
+* Establish New User Stories:  
+  * Team members are actively engaged in ongoing development tasks.  
+  * Grayson:   
+    * Assigned the implementation of the workout screen, addition of a breathing screen to the mental health screen, and research into video sources.  
+
+Action items
+
+- [x] ~~Celebrate being the example~~  
+- [x] ~~Daily standup~~  
+- [x] ~~Establish new user stories~~  
+      - [x] ~~Every story includes acceptance criteria~~   
+      - [x] ~~Each story is assigned to one person~~   
+      - [x] ~~Each story is small enough for one week~~   
+      - [x] ~~Each story will have its own branch~~  
+      - [x] ~~Each listed as an issue~~


### PR DESCRIPTION
Add meeting notes for Team 2 (Apr 7, 2026) including attendees and standup updates: Grayson (UI onboarding color fixes; implementing mental health screen; workout screen & video source research), Jonathan (backend video embedding issues), Lin (video integration research), Alicia (system instability; workout layouts). Also records new user stories and completed action items.