### PR TITLE
Add workouts & exercise list screens

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/MainActivity.kt
+++ b/app/src/main/java/com/team2/studentfitness/MainActivity.kt
@@ -28,6 +28,8 @@ import com.team2.studentfitness.ui.screens.Dashboard
 import com.team2.studentfitness.ui.screens.LoginScreen
 import com.team2.studentfitness.ui.screens.OnboardingScreen
 import com.team2.studentfitness.ui.screens.SettingsScreen
+import com.team2.studentfitness.ui.screens.WorkoutScreen
+import com.team2.studentfitness.ui.screens.ExerciseListScreen
 import com.team2.studentfitness.ui.theme.StudentFitnessTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -120,6 +122,24 @@ class MainActivity : ComponentActivity() {
                                         popUpTo(AppRoutes.Dashboard) { inclusive = true }
                                     }
                                 }
+                            )
+                        }
+                        composable(AppRoutes.Workouts) {
+                            WorkoutScreen(navController = navController)
+                        }
+                        composable(
+                            route = AppRoutes.ExerciseListTemplate,
+                            arguments = listOf(
+                                navArgument("workoutId") { type = NavType.IntType },
+                                navArgument("workoutName") { type = NavType.StringType }
+                            )
+                        ) { backStackEntry ->
+                            val workoutId = backStackEntry.arguments?.getInt("workoutId") ?: 0
+                            val workoutName = backStackEntry.arguments?.getString("workoutName") ?: "Exercises"
+                            ExerciseListScreen(
+                                navController = navController,
+                                workoutId = workoutId,
+                                workoutName = workoutName
                             )
                         }
                         composable(

--- a/app/src/main/java/com/team2/studentfitness/ui/navigation/ScreenMenu.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/navigation/ScreenMenu.kt
@@ -11,8 +11,11 @@ object AppRoutes {
     const val Dashboard = "dashboard"
     const val Settings = "settings"
     const val DeveloperMenu = "dev-menu"
+    const val Workouts = "workouts"
+    const val ExerciseListTemplate = "exercises/{workoutId}/{workoutName}"
     const val DetailTemplate = "detail/{feature}"
 
+    fun exercises(workoutId: Int, workoutName: String): String = "exercises/$workoutId/$workoutName"
     fun detail(feature: String): String = "detail/$feature"
 }
 
@@ -22,6 +25,7 @@ val ScreenMenu = listOf(
     ScreenMenuItem(title = "Onboarding", route = AppRoutes.Onboarding),
     ScreenMenuItem(title = "Dashboard", route = AppRoutes.Dashboard),
     ScreenMenuItem(title = "Settings", route = AppRoutes.Settings),
+    ScreenMenuItem(title = "Workouts", route = AppRoutes.Workouts),
     ScreenMenuItem(title = "Detail: Heart Rate", route = AppRoutes.detail("Heart Rate")),
     ScreenMenuItem(title = "Detail: Calories", route = AppRoutes.detail("Calories")),
     ScreenMenuItem(title = "Detail: Gym Hours", route = AppRoutes.detail("Gym Hours")),

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/Dashboard.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/Dashboard.kt
@@ -353,7 +353,7 @@ fun WorkoutTabContent(navController: NavController, healthData: HealthData?, use
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(
-                        onClick = { navController.navigate(AppRoutes.detail("Workouts")) },
+                        onClick = { navController.navigate(AppRoutes.Workouts) },
                         colors = ButtonDefaults.buttonColors(containerColor = Color.White),
                         shape = RoundedCornerShape(8.dp),
                         contentPadding = PaddingValues(horizontal = 24.dp)

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseListScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseListScreen.kt
@@ -1,0 +1,162 @@
+package com.team2.studentfitness.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.team2.studentfitness.DatabaseCreation
+import com.team2.studentfitness.database.Exercises
+import com.team2.studentfitness.database.WorkEx
+import com.team2.studentfitness.ui.theme.Teal
+import com.team2.studentfitness.viewmodels.WorkoutViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExerciseListScreen(
+    navController: NavController,
+    workoutId: Int,
+    workoutName: String,
+    workoutViewModel: WorkoutViewModel = viewModel()
+) {
+    val context = LocalContext.current
+    val database = (context.applicationContext as DatabaseCreation).database
+    val settingsDao = database.settingsDao()
+    val userSettings by settingsDao.getLatestFlow().collectAsState(initial = null)
+    val isDark = userSettings?.theme == 1
+
+    val selectedWorkoutExercises by workoutViewModel.selectedWorkoutExercises.collectAsState()
+
+    LaunchedEffect(workoutId) {
+        // We need a way to load by ID directly or find the workout object
+        val workout = database.workoutsDao().getById(workoutId)
+        if (workout != null) {
+            workoutViewModel.loadExercisesForWorkout(workout)
+        }
+    }
+
+    val textColor = if (isDark) Color.White else Color.Black
+    val backgroundColor = if (isDark) Color.Black else Teal
+    val cardBackground = if (isDark) Color(0xFF1E1E1E) else Color.White
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(workoutName, fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = backgroundColor,
+                    titleContentColor = if (isDark) Color.White else Color.Black,
+                    navigationIconContentColor = if (isDark) Color.White else Color.Black
+                )
+            )
+        },
+        containerColor = backgroundColor
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 24.dp)
+        ) {
+            if (selectedWorkoutExercises.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = Color(0xFFF7A643))
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(vertical = 16.dp)
+                ) {
+                    items(selectedWorkoutExercises) { (workEx, exercise) ->
+                        ExerciseCard(workEx, exercise, cardBackground, textColor)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ExerciseCard(workEx: WorkEx, exercise: Exercises, backgroundColor: Color, textColor: Color) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = exercise.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = textColor
+                )
+                Surface(
+                    color = Teal.copy(alpha = 0.2f),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text(
+                        text = exercise.muscleGroup,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (backgroundColor == Color.White) Teal else Color.White
+                    )
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                Column {
+                    Text("SETS", style = MaterialTheme.typography.labelSmall, color = textColor.copy(alpha = 0.6f))
+                    Text("${workEx.sets}", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = textColor)
+                }
+                Column {
+                    Text("REPS", style = MaterialTheme.typography.labelSmall, color = textColor.copy(alpha = 0.6f))
+                    Text("${workEx.reps}", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = textColor)
+                }
+                if (workEx.restTime > 0) {
+                    Column {
+                        Text("REST", style = MaterialTheme.typography.labelSmall, color = textColor.copy(alpha = 0.6f))
+                        Text("${workEx.restTime}s", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = textColor)
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(12.dp))
+            
+            Text(
+                text = exercise.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = textColor.copy(alpha = 0.8f),
+                lineHeight = 18.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/WorkoutScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/WorkoutScreen.kt
@@ -1,0 +1,231 @@
+package com.team2.studentfitness.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.team2.studentfitness.DatabaseCreation
+import com.team2.studentfitness.database.WorkEx
+import com.team2.studentfitness.database.Workouts
+import com.team2.studentfitness.ui.navigation.AppRoutes
+import com.team2.studentfitness.ui.theme.*
+import com.team2.studentfitness.viewmodels.WorkoutViewModel
+
+@Composable
+fun WorkoutScreen(navController: NavController, workoutViewModel: WorkoutViewModel = viewModel()) {
+    val context = LocalContext.current
+    val database = (context.applicationContext as DatabaseCreation).database
+    val settingsDao = database.settingsDao()
+    val userSettings by settingsDao.getLatestFlow().collectAsState(initial = null)
+    val isDark = userSettings?.theme == 1
+
+    val workouts by workoutViewModel.workouts.collectAsState()
+    val isLoading by workoutViewModel.isLoading.collectAsState()
+
+    val textColor = if (isDark) Color.White else Color.Black
+    val backgroundColor = if (isDark) Color.Black else Teal
+    val cardBackground = if (isDark) Color(0xFF1E1E1E) else Color.White
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundColor)
+            .padding(24.dp)
+    ) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Workout",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (isDark) Color.White else Color.Black
+            )
+            IconButton(onClick = { navController.navigate(AppRoutes.Settings) }) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = "Settings",
+                    tint = if (isDark) Color.White else Color.Black
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Difficulty and Muscle Group Selection Row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Difficulty Selection (Left)
+            Card(
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = if (isDark) Color(0xFF2C3E50) else Color(0xFF648CF4))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Difficulty", color = Color.White, fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    DifficultyButton(1) { workoutViewModel.loadWorkoutsByDifficulty(0) }
+                    DifficultyButton(2) { workoutViewModel.loadWorkoutsByDifficulty(1) }
+                    DifficultyButton(3) { workoutViewModel.loadWorkoutsByDifficulty(2) }
+                }
+            }
+
+            // Muscle Group Selection (Right)
+            Card(
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = if (isDark) Color(0xFF5D4037) else Color(0xFFF7A643))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Muscle Group", color = Color.White, fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    // Removed "Glutes" as it was causing empty results in the current dataset
+                    val muscleGroups = listOf("Biceps", "Legs", "Chest", "Core", "Back")
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        muscleGroups.forEach { group ->
+                            MuscleGroupChip(group) { workoutViewModel.loadWorkoutsByMuscleGroup(group) }
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Workout List
+        Text(
+            text = "Workouts",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = if (isDark) Color.White else Color.Black,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        if (isLoading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally), color = Orange)
+        } else {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(workouts) { workout ->
+                    WorkoutItem(workout, cardBackground, textColor) {
+                        navController.navigate(AppRoutes.exercises(workout.uid, workout.name))
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Build Button
+        Button(
+            onClick = { /* Handle Build */ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = if (isDark) Orange else Color(0xFFF7A643)),
+            shape = RoundedCornerShape(28.dp)
+        ) {
+            Text("Build", fontSize = 24.sp, fontWeight = FontWeight.Bold, color = Color.White)
+        }
+    }
+}
+
+@Composable
+fun DifficultyButton(stars: Int, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable { onClick() },
+        color = Color.White.copy(alpha = 0.9f),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            repeat(3) { index ->
+                Icon(
+                    imageVector = if (index < stars) Icons.Default.Star else Icons.Default.StarBorder,
+                    contentDescription = null,
+                    tint = if (index < stars) Color(0xFFF1C40F) else Color.Gray,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MuscleGroupChip(group: String, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        color = Color.White,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Text(
+            text = group,
+            modifier = Modifier.padding(vertical = 4.dp),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black
+        )
+    }
+}
+
+@Composable
+fun WorkoutItem(workout: Workouts, backgroundColor: Color, textColor: Color, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Text(workout.name, fontWeight = FontWeight.Bold, color = textColor)
+                Text("${workout.duration} min • ${workout.focus}", style = MaterialTheme.typography.bodySmall, color = textColor.copy(alpha = 0.7f))
+            }
+            Icon(
+                imageVector = Icons.Default.PlayArrow,
+                contentDescription = "View Exercises",
+                tint = Color(0xFFD32F2F),
+                modifier = Modifier.size(32.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/team2/studentfitness/viewmodels/WorkoutViewModel.kt
+++ b/app/src/main/java/com/team2/studentfitness/viewmodels/WorkoutViewModel.kt
@@ -1,0 +1,66 @@
+package com.team2.studentfitness.viewmodels
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.team2.studentfitness.DatabaseCreation
+import com.team2.studentfitness.database.Exercises
+import com.team2.studentfitness.database.WorkEx
+import com.team2.studentfitness.database.Workouts
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class WorkoutViewModel(application: Application) : AndroidViewModel(application) {
+    private val database = (application as DatabaseCreation).database
+    private val workoutsDao = database.workoutsDao()
+    private val exercisesDao = database.exercisesDao()
+    private val workExDao = database.workExDao()
+
+    private val _workouts = MutableStateFlow<List<Workouts>>(emptyList())
+    val workouts: StateFlow<List<Workouts>> = _workouts
+
+    private val _selectedWorkoutExercises = MutableStateFlow<List<Pair<WorkEx, Exercises>>>(emptyList())
+    val selectedWorkoutExercises: StateFlow<List<Pair<WorkEx, Exercises>>> = _selectedWorkoutExercises
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    fun loadWorkoutsByDifficulty(difficulty: Int) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _workouts.value = workoutsDao.getByDifficulty(difficulty)
+            _isLoading.value = false
+        }
+    }
+
+    fun loadWorkoutsByMuscleGroup(muscleGroup: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            // Find exercises with this muscle group
+            val exercises = exercisesDao.getByMuscleGroup(muscleGroup)
+            val exerciseIds = exercises.map { it.uid }.toSet()
+            
+            // Find all WorkEx that use these exercises
+            val allWorkEx = workExDao.getAll()
+            val workoutIds = allWorkEx.filter { it.exerciseID in exerciseIds }.map { it.userID }.toSet()
+            
+            // Get the actual workouts
+            val allWorkouts = workoutsDao.getAll()
+            _workouts.value = allWorkouts.filter { it.uid in workoutIds }
+            _isLoading.value = false
+        }
+    }
+
+    fun loadExercisesForWorkout(workout: Workouts) {
+        viewModelScope.launch {
+            // In WorkEx, workoutID is stored in the 'userID' field based on the Entity definition
+            val workExList = workExDao.getAll().filter { it.userID == workout.uid }.sortedBy { it.order }
+            val pairs = workExList.mapNotNull { workEx ->
+                val exercise = exercisesDao.getById(workEx.exerciseID)
+                if (exercise != null) workEx to exercise else null
+            }
+            _selectedWorkoutExercises.value = pairs
+        }
+    }
+}


### PR DESCRIPTION
Introduce Workout and ExerciseList UI plus WorkoutViewModel and navigation. Adds AppRoutes.Workouts and exercises route template (exercises/{workoutId}/{workoutName}) and ScreenMenu entry, and updates Dashboard button to navigate to the new Workouts screen. New files: WorkoutScreen (workout list, difficulty/muscle filters, navigation to exercises) and ExerciseListScreen (loads exercises for a workout and displays ExerciseCard entries). Adds WorkoutViewModel to load workouts by difficulty or muscle group and to load exercises for a selected workout. MainActivity updated to register the new composable routes. Uses existing database DAOs to fetch data and user theme settings for styling.