### PR TITLE
Add workout builder & exercise selection screens

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/MainActivity.kt
+++ b/app/src/main/java/com/team2/studentfitness/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : ComponentActivity() {
                 val securePinManager = remember { SecurePinManager(context) }
                 val loginViewModel = remember { LoginViewModel(securePinManager) }
                 val onboardingViewModel = remember { OnboardingViewModel(application, securePinManager) }
+                val workoutViewModel: WorkoutViewModel = viewModel()
 
                 val startDestination = if (onboardingViewModel.isOnboardingCompleted()) {
                     if (securePinManager.isPinSet()) AppRoutes.Login else AppRoutes.Dashboard
@@ -120,8 +121,21 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                         composable(AppRoutes.Workouts) {
-                            val workoutViewModel: WorkoutViewModel = viewModel()
                             WorkoutScreen(navController = navController, workoutViewModel = workoutViewModel)
+                        }
+                        composable(AppRoutes.BuildWorkout) {
+                            BuildWorkoutScreen(navController = navController, workoutViewModel = workoutViewModel)
+                        }
+                        composable(
+                            route = AppRoutes.ExerciseSelection,
+                            arguments = listOf(navArgument("muscleGroup") { type = NavType.StringType })
+                        ) { backStackEntry ->
+                            val muscleGroup = backStackEntry.arguments?.getString("muscleGroup") ?: ""
+                            ExerciseSelectionScreen(
+                                navController = navController,
+                                muscleGroup = muscleGroup,
+                                workoutViewModel = workoutViewModel
+                            )
                         }
                         composable(AppRoutes.Macros) {
                             MacroScreen(navController = navController)
@@ -141,7 +155,8 @@ class MainActivity : ComponentActivity() {
                             ExerciseListScreen(
                                 navController = navController,
                                 workoutId = workoutId,
-                                workoutName = workoutName
+                                workoutName = workoutName,
+                                workoutViewModel = workoutViewModel
                             )
                         }
                         composable(

--- a/app/src/main/java/com/team2/studentfitness/database/WorkoutsDao.kt
+++ b/app/src/main/java/com/team2/studentfitness/database/WorkoutsDao.kt
@@ -12,13 +12,13 @@ interface WorkoutsDao {
     suspend fun getAll(): List<Workouts>
 
     @Query("SELECT * FROM Workouts WHERE uid = :uid")
-    suspend fun getById(uid: Int): Workouts
+    suspend fun getById(uid: Int): Workouts?
 
     @Query("SELECT * FROM Workouts WHERE name = :name")
     suspend fun getByName(name: String): List<Workouts>
 
     @Insert()
-    suspend fun insert(workouts: Workouts)
+    suspend fun insert(workouts: Workouts): Long
 
     @Delete()
     suspend fun delete(workouts: Workouts)

--- a/app/src/main/java/com/team2/studentfitness/ui/navigation/ScreenMenu.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/navigation/ScreenMenu.kt
@@ -12,12 +12,15 @@ object AppRoutes {
     const val Settings = "settings"
     const val DeveloperMenu = "dev-menu"
     const val Workouts = "workouts"
+    const val BuildWorkout = "build-workout"
+    const val ExerciseSelection = "exercise-selection/{muscleGroup}"
     const val ExerciseListTemplate = "exercises/{workoutId}/{workoutName}"
     const val DetailTemplate = "detail/{feature}"
     const val Macros = "macros"
     const val WeightProgress = "weight-progress"
 
     fun exercises(workoutId: Int, workoutName: String): String = "exercises/$workoutId/$workoutName"
+    fun exerciseSelection(muscleGroup: String): String = "exercise-selection/$muscleGroup"
     fun detail(feature: String): String = "detail/$feature"
 }
 
@@ -28,6 +31,7 @@ val ScreenMenu = listOf(
     ScreenMenuItem(title = "Dashboard", route = AppRoutes.Dashboard),
     ScreenMenuItem(title = "Settings", route = AppRoutes.Settings),
     ScreenMenuItem(title = "Workouts", route = AppRoutes.Workouts),
+    ScreenMenuItem(title = "Build Workout", route = AppRoutes.BuildWorkout),
     ScreenMenuItem(title = "Macros", route = AppRoutes.Macros),
     ScreenMenuItem(title = "Weight Progress", route = AppRoutes.WeightProgress),
     ScreenMenuItem(title = "Detail: Heart Rate", route = AppRoutes.detail("Heart Rate")),

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/BuildWorkoutScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/BuildWorkoutScreen.kt
@@ -1,0 +1,227 @@
+package com.team2.studentfitness.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.team2.studentfitness.DatabaseCreation
+import com.team2.studentfitness.database.Exercises
+import com.team2.studentfitness.ui.navigation.AppRoutes
+import com.team2.studentfitness.ui.theme.Teal
+import com.team2.studentfitness.ui.theme.Orange
+import com.team2.studentfitness.viewmodels.WorkoutViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BuildWorkoutScreen(navController: NavController, workoutViewModel: WorkoutViewModel = viewModel()) {
+    val context = LocalContext.current
+    val database = (context.applicationContext as DatabaseCreation).database
+    val settingsDao = database.settingsDao()
+    val userSettings by settingsDao.getLatestFlow().collectAsState(initial = null)
+    val isDark = userSettings?.theme == 1
+
+    val newWorkoutExercises by workoutViewModel.newWorkoutExercises.collectAsState()
+    var workoutName by remember { mutableStateOf("") }
+
+    val textColor = if (isDark) Color.White else Color.Black
+    val backgroundColor = if (isDark) Color.Black else Teal
+    val cardBackground = if (isDark) Color(0xFF1E1E1E) else Color(0xFFF7A643).copy(alpha = 0.8f)
+    val listBackground = if (isDark) Color(0xFF2C2C2C) else Color.White.copy(alpha = 0.9f)
+
+    val muscleGroups = listOf(
+        "Biceps", "Legs", "Core", "Chest", "Back", "Glutes"
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundColor)
+            .padding(24.dp)
+    ) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Muscle Group",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = textColor
+            )
+            IconButton(onClick = { navController.navigate(AppRoutes.Settings) }) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = "Settings",
+                    tint = textColor
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Search Bar (Workout Name)
+        TextField(
+            value = workoutName,
+            onValueChange = { workoutName = it },
+            placeholder = { Text("Workout Name", color = textColor.copy(alpha = 0.5f)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = if (isDark) Color(0xFF2C2C2C) else Color.White.copy(alpha = 0.8f),
+                unfocusedContainerColor = if (isDark) Color(0xFF2C2C2C) else Color.White.copy(alpha = 0.8f),
+                focusedTextColor = textColor,
+                unfocusedTextColor = textColor
+            ),
+            shape = RoundedCornerShape(28.dp)
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Muscle Group Grid
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = Modifier.height(360.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(muscleGroups) { group ->
+                MuscleGroupCard(group, cardBackground, textColor) {
+                    navController.navigate(AppRoutes.exerciseSelection(group))
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Current Exercises List
+        Text(
+            text = "Current Workout Exercises",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = textColor
+        )
+        
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(listBackground, RoundedCornerShape(16.dp))
+                .padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (newWorkoutExercises.isEmpty()) {
+                item {
+                    Text(
+                        "No exercises added yet.",
+                        modifier = Modifier.padding(16.dp),
+                        color = textColor.copy(alpha = 0.5f)
+                    )
+                }
+            } else {
+                items(newWorkoutExercises) { exercise ->
+                    AddedExerciseItem(exercise, textColor) {
+                        workoutViewModel.removeExerciseFromNewWorkout(exercise)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Build Button
+        Button(
+            onClick = {
+                if (workoutName.isNotBlank() && newWorkoutExercises.isNotEmpty()) {
+                    workoutViewModel.saveCustomWorkout(workoutName) {
+                        navController.navigateUp()
+                    }
+                }
+            },
+            enabled = workoutName.isNotBlank() && newWorkoutExercises.isNotEmpty(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (isDark) Orange else Color(0xFFF7A643),
+                disabledContainerColor = Color.Gray
+            ),
+            shape = RoundedCornerShape(28.dp)
+        ) {
+            Text("Build", fontSize = 24.sp, fontWeight = FontWeight.Bold, color = Color.White)
+        }
+    }
+}
+
+@Composable
+fun MuscleGroupCard(group: String, backgroundColor: Color, textColor: Color, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            // Placeholder for exercise icons - in real app we'd use local drawables
+            Text(
+                text = group,
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .background(Color.White.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
+                    .padding(horizontal = 12.dp, vertical = 2.dp),
+                fontWeight = FontWeight.Bold,
+                color = Color.Black,
+                fontSize = 14.sp
+            )
+        }
+    }
+}
+
+@Composable
+fun AddedExerciseItem(exercise: Exercises, textColor: Color, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(exercise.name, fontWeight = FontWeight.Bold, color = textColor)
+            Text(exercise.muscleGroup, fontSize = 12.sp, color = textColor.copy(alpha = 0.7f))
+        }
+        IconButton(onClick = onRemove) {
+            Icon(Icons.Default.Close, contentDescription = "Remove", tint = Color.Red)
+        }
+    }
+}

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseSelectionScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseSelectionScreen.kt
@@ -1,0 +1,155 @@
+package com.team2.studentfitness.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.team2.studentfitness.DatabaseCreation
+import com.team2.studentfitness.database.Exercises
+import com.team2.studentfitness.ui.theme.Teal
+import com.team2.studentfitness.viewmodels.WorkoutViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExerciseSelectionScreen(
+    navController: NavController,
+    muscleGroup: String,
+    workoutViewModel: WorkoutViewModel = viewModel()
+) {
+    val context = LocalContext.current
+    val database = (context.applicationContext as DatabaseCreation).database
+    val settingsDao = database.settingsDao()
+    val userSettings by settingsDao.getLatestFlow().collectAsState(initial = null)
+    val isDark = userSettings?.theme == 1
+
+    val categoryExercises by workoutViewModel.categoryExercises.collectAsState()
+    val selectedExercises by workoutViewModel.newWorkoutExercises.collectAsState()
+    val isLoading by workoutViewModel.isLoading.collectAsState()
+
+    LaunchedEffect(muscleGroup) {
+        workoutViewModel.loadExercisesByCategory(muscleGroup)
+    }
+
+    val textColor = if (isDark) Color.White else Color.Black
+    val backgroundColor = if (isDark) Color.Black else Teal
+    val cardBackground = if (isDark) Color(0xFF1E1E1E) else Color.White
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(muscleGroup, fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = backgroundColor,
+                    titleContentColor = textColor,
+                    navigationIconContentColor = textColor
+                )
+            )
+        },
+        containerColor = backgroundColor
+    ) { paddingValues ->
+        if (isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Color(0xFFF7A643))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(vertical = 16.dp)
+            ) {
+                items(categoryExercises) { exercise ->
+                    val isSelected = selectedExercises.any { it.uid == exercise.uid }
+                    
+                    SelectionExerciseCard(
+                        exercise = exercise,
+                        isSelected = isSelected,
+                        backgroundColor = cardBackground,
+                        textColor = textColor,
+                        onSelect = {
+                            if (isSelected) {
+                                workoutViewModel.removeExerciseFromNewWorkout(exercise)
+                            } else {
+                                workoutViewModel.addExerciseToNewWorkout(exercise)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SelectionExerciseCard(
+    exercise: Exercises,
+    isSelected: Boolean,
+    backgroundColor: Color,
+    textColor: Color,
+    onSelect: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onSelect() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor),
+        border = if (isSelected) androidx.compose.foundation.BorderStroke(2.dp, Color(0xFFF7A643)) else null
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = exercise.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = textColor
+                )
+                Text(
+                    text = exercise.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = textColor.copy(alpha = 0.7f),
+                    maxLines = 2
+                )
+            }
+            
+            IconButton(onClick = onSelect) {
+                Icon(
+                    imageVector = if (isSelected) Icons.Default.Check else Icons.Default.Add,
+                    contentDescription = if (isSelected) "Selected" else "Add",
+                    tint = if (isSelected) Color(0xFFF7A643) else textColor.copy(alpha = 0.5f)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/WorkoutScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/WorkoutScreen.kt
@@ -155,7 +155,7 @@ fun WorkoutScreen(navController: NavController, workoutViewModel: WorkoutViewMod
 
         // Build Button
         Button(
-            onClick = { /* Handle Build */ },
+            onClick = { navController.navigate(AppRoutes.BuildWorkout) },
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),

--- a/app/src/main/java/com/team2/studentfitness/viewmodels/WorkoutViewModel.kt
+++ b/app/src/main/java/com/team2/studentfitness/viewmodels/WorkoutViewModel.kt
@@ -26,6 +26,13 @@ class WorkoutViewModel(application: Application) : AndroidViewModel(application)
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
+    // --- State for Building Workout ---
+    private val _newWorkoutExercises = MutableStateFlow<List<Exercises>>(emptyList())
+    val newWorkoutExercises: StateFlow<List<Exercises>> = _newWorkoutExercises
+
+    private val _categoryExercises = MutableStateFlow<List<Exercises>>(emptyList())
+    val categoryExercises: StateFlow<List<Exercises>> = _categoryExercises
+
     fun loadWorkoutsByDifficulty(difficulty: Int) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -54,13 +61,90 @@ class WorkoutViewModel(application: Application) : AndroidViewModel(application)
 
     fun loadExercisesForWorkout(workout: Workouts) {
         viewModelScope.launch {
-            // In WorkEx, workoutID is stored in the 'userID' field based on the Entity definition
             val workExList = workExDao.getAll().filter { it.userID == workout.uid }.sortedBy { it.order }
             val pairs = workExList.mapNotNull { workEx ->
                 val exercise = exercisesDao.getById(workEx.exerciseID)
                 if (exercise != null) workEx to exercise else null
             }
             _selectedWorkoutExercises.value = pairs
+        }
+    }
+
+    // --- Building Workout Methods ---
+
+    fun loadExercisesByCategory(muscleGroup: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _categoryExercises.value = exercisesDao.getByMuscleGroup(muscleGroup)
+            _isLoading.value = false
+        }
+    }
+
+    fun addExerciseToNewWorkout(exercise: Exercises) {
+        // Only add if not already present
+        if (!_newWorkoutExercises.value.any { it.uid == exercise.uid }) {
+            _newWorkoutExercises.value = _newWorkoutExercises.value + exercise
+        }
+    }
+
+    fun removeExerciseFromNewWorkout(exercise: Exercises) {
+        _newWorkoutExercises.value = _newWorkoutExercises.value.filter { it.uid != exercise.uid }
+    }
+
+    fun clearNewWorkout() {
+        _newWorkoutExercises.value = emptyList()
+    }
+
+    fun saveCustomWorkout(name: String, onComplete: () -> Unit) {
+        val exercises = _newWorkoutExercises.value
+        if (exercises.isEmpty()) return
+
+        viewModelScope.launch {
+            // Calculate Difficulty (Average)
+            val avgDifficulty = if (exercises.isNotEmpty()) {
+                exercises.map { it.difficulty }.average().toInt().coerceIn(0, 2)
+            } else 0
+            
+            // Determine Focus (Most frequent muscle group or "Mixed")
+            val muscleGroups = exercises.map { it.muscleGroup }
+            val focus = if (muscleGroups.distinct().size == 1) muscleGroups.first() else "Mixed"
+            
+            // Estimate Duration (e.g., 10 mins per exercise)
+            val duration = exercises.size * 10
+
+            // Create Workout
+            val newWorkout = Workouts(
+                uid = 0, // Auto-generate
+                name = name,
+                duration = duration,
+                focus = focus,
+                type = 2, // Default to Strength for custom
+                difficulty = avgDifficulty,
+                split = focus
+            )
+
+            // Insert Workout and get ID
+            val newWorkoutId = workoutsDao.insert(newWorkout).toInt()
+            
+            // Insert WorkEx entries
+            exercises.forEachIndexed { index, exercise ->
+                val workEx = WorkEx(
+                    uid = 0,
+                    workoutName = name,
+                    userID = newWorkoutId,
+                    exerciseID = exercise.uid,
+                    reps = 10, // Default values
+                    sets = 3,
+                    restTime = 60,
+                    order = index
+                )
+                workExDao.insert(workEx)
+            }
+            
+            clearNewWorkout()
+            // Reload workouts to include the new one
+            loadWorkoutsByDifficulty(avgDifficulty)
+            onComplete()
         }
     }
 }


### PR DESCRIPTION
Introduce a new workout-building flow and wire it into navigation. Adds two new Compose screens: BuildWorkoutScreen and ExerciseSelectionScreen, with UI for selecting muscle groups, picking exercises, previewing current workout exercises, and saving a custom workout. Update navigation (AppRoutes / ScreenMenu) and MainActivity to provide a shared WorkoutViewModel and routes for BuildWorkout and ExerciseSelection.

Enhance WorkoutViewModel with state and methods for building workouts: newWorkoutExercises, categoryExercises, loadExercisesByCategory, add/remove/clear exercises, and saveCustomWorkout (creates Workouts + WorkEx entries, estimates difficulty/focus/duration). Update WorkoutScreen to navigate to the new BuildWorkout route.

Make small DAO changes: WorkoutsDao.getById() now returns nullable and insert() returns Long. These changes support inserting new workouts and handling absent records.

Overall: adds UI + ViewModel logic for creating custom workouts, navigation integration, and required DAO adjustments for persistence.