### PR TITLE
107 fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,12 @@ WORKDIR /app
 COPY gradlew gradlew.bat gradle.properties settings.gradle.kts build.gradle.kts ./
 COPY gradle/ gradle/
 
-# Make Gradle wrapper executable and pre-download Gradle distribution
-RUN chmod +x gradlew && ./gradlew --version
+# Normalize shell scripts from Windows checkouts and pre-download Gradle
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew && ./gradlew --version
+
+# Keep install script in the image (avoids host line-ending issues on bind mounts)
+COPY docker/install-apk.sh /usr/local/bin/install-apk.sh
+RUN sed -i 's/\r$//' /usr/local/bin/install-apk.sh && chmod +x /usr/local/bin/install-apk.sh
 
 # Copy the rest of the project
 COPY app/ app/

--- a/README.docker.md
+++ b/README.docker.md
@@ -154,7 +154,7 @@ docker compose down
 ### `docker-compose.yml`
 - **`build`** — runs `./gradlew assembleDebug --no-daemon` and writes the debug APK to mounted `app/build/outputs/` on the host.
 - **`test`** — runs JVM unit tests; mounts `app/build/reports/` to the host.
-- **`emulator`** — runs [`budtmo/docker-android:emulator_14.0`](https://github.com/budtmo/docker-android), an Android 14 emulator with a web VNC interface on port 6080.
+- **`emulator`** — runs [`budtmo/docker-android:emulator_14.0`](https://github.com/budtmo/docker-android), an Android 14 emulator with a web VNC interface on port 6080. Resource limits are set to 4 CPUs / 4 GB RAM (with 2 CPUs / 2 GB reserved) so the emulator has enough headroom to boot reliably.
 - **`install`** — uses the build image's ADB to connect to the emulator and install the APK; delegates to the image-bundled install script.
 
 ### `docker/install-apk.sh`
@@ -167,6 +167,7 @@ Polls the emulator via ADB until `sys.boot_completed=1`, then runs `adb install`
 - First-time emulator pulls and image builds take several minutes. Subsequent starts are much faster.
 - Emulator data (installed apps, settings) is persisted in the `emulator-data` Docker volume across restarts.
 - To wipe the emulator data: `docker compose down -v`
+- The emulator service is configured with **4 CPU / 4 GB RAM** limits and **2 CPU / 2 GB RAM** reservations. If your machine has fewer resources, edit the `deploy.resources` section in `docker-compose.yml` to match what is available. Docker Desktop users should ensure the resource sliders in **Settings → Resources** give Docker at least 2 CPUs and 3 GB of RAM.
 - To force a clean rebuild of the build image:
   ```bash
   docker compose build --no-cache

--- a/README.docker.md
+++ b/README.docker.md
@@ -148,13 +148,14 @@ docker compose down
 ### `Dockerfile`
 1. Starts from an **Eclipse Temurin JDK 17** base image (required by AGP 9.x).
 2. Installs the **Android SDK command-line tools**, `platform-tools`, `platforms;android-36`, and `build-tools;36.0.0`.
-3. Copies the project and runs `./gradlew assembleDebug` to produce the APK.
+3. Normalizes line endings for shell scripts so Docker builds also work from Windows checkouts.
+4. Copies the project and runs `./gradlew assembleDebug` to produce the APK.
 
 ### `docker-compose.yml`
 - **`build`** — builds the debug APK; mounts `app/build/outputs/` to the host.
 - **`test`** — runs JVM unit tests; mounts `app/build/reports/` to the host.
 - **`emulator`** — runs [`budtmo/docker-android:emulator_14.0`](https://github.com/budtmo/docker-android), an Android 14 emulator with a web VNC interface on port 6080.
-- **`install`** — uses the build image's ADB to connect to the emulator and install the APK; delegates to `docker/install-apk.sh`.
+- **`install`** — uses the build image's ADB to connect to the emulator and install the APK; delegates to the image-bundled install script.
 
 ### `docker/install-apk.sh`
 Polls the emulator via ADB until `sys.boot_completed=1`, then runs `adb install`.

--- a/README.docker.md
+++ b/README.docker.md
@@ -152,7 +152,7 @@ docker compose down
 4. Copies the project and runs `./gradlew assembleDebug` to produce the APK.
 
 ### `docker-compose.yml`
-- **`build`** — builds the debug APK; mounts `app/build/outputs/` to the host.
+- **`build`** — runs `./gradlew assembleDebug --no-daemon` and writes the debug APK to mounted `app/build/outputs/` on the host.
 - **`test`** — runs JVM unit tests; mounts `app/build/reports/` to the host.
 - **`emulator`** — runs [`budtmo/docker-android:emulator_14.0`](https://github.com/budtmo/docker-android), an Android 14 emulator with a web VNC interface on port 6080.
 - **`install`** — uses the build image's ADB to connect to the emulator and install the APK; delegates to the image-bundled install script.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: ["./gradlew", "assembleDebug", "--no-daemon"]
     volumes:
       - ./app/build/outputs:/app/app/build/outputs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,7 @@ services:
       - emulator
     volumes:
       - ./app/build/outputs:/app/app/build/outputs
-      - ./docker/install-apk.sh:/install-apk.sh:ro
-    entrypoint: ["/bin/bash", "/install-apk.sh"]
+    entrypoint: ["/bin/bash", "/usr/local/bin/install-apk.sh"]
     environment:
       EMULATOR_HOST: "emulator"
       EMULATOR_ADB_PORT: "5555"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,14 @@ services:
       WEB_VNC: "true"
     volumes:
       - emulator-data:/home/androidusr
+    deploy:
+      resources:
+        limits:
+          cpus: "4"       # Allow up to 4 CPU cores
+          memory: "4G"    # Allow up to 4 GB RAM
+        reservations:
+          cpus: "2"       # Reserve at least 2 CPU cores
+          memory: "2G"    # Reserve at least 2 GB RAM
 
   # ── Install APK ────────────────────────────────────────────────────────────
   # Waits for the emulator to finish booting, then installs the debug APK.


### PR DESCRIPTION
This pull request improves cross-platform Docker support, especially for Windows users, and enhances Android emulator reliability in the development environment. The main changes include normalizing shell script line endings to avoid issues with Windows checkouts, updating resource limits for the emulator, and clarifying documentation to reflect these improvements.

**Cross-platform compatibility and script handling:**
* Updated the `Dockerfile` to normalize line endings for shell scripts (`gradlew`, `install-apk.sh`) using `sed`, ensuring scripts work correctly when checked out on Windows. The install script is now copied into the image to avoid host line-ending issues on bind mounts.

**Docker Compose configuration improvements:**
* Added a `command` to the `build` service in `docker-compose.yml` to run `./gradlew assembleDebug --no-daemon`, making the build process more explicit and reliable.
* Updated the `install` service to use the image-bundled install script at `/usr/local/bin/install-apk.sh` instead of mounting it from the host, further preventing line-ending problems.
* Configured the `emulator` service with resource limits (4 CPUs, 4 GB RAM) and reservations (2 CPUs, 2 GB RAM) to improve emulator reliability and boot success.

**Documentation updates:**
* Revised `README.docker.md` to document the new script normalization process, clarify the build and install steps, and explain the emulator resource requirements and how to adjust them. [[1]](diffhunk://#diff-97290646ec29806fd928fa2a5771dea2200480f4d3ddf71dff976fe76d939d85L151-R158) [[2]](diffhunk://#diff-97290646ec29806fd928fa2a5771dea2200480f4d3ddf71dff976fe76d939d85R170)