### PR TITLE
88 video integration and source

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/MainActivity.kt
+++ b/app/src/main/java/com/team2/studentfitness/MainActivity.kt
@@ -120,6 +120,15 @@ class MainActivity : ComponentActivity() {
                                 }
                             )
                         }
+<<<<<<< Updated upstream
+=======
+                        composable(AppRoutes.VideoDemo) {
+                            VideoDemoScreen()
+                        }
+                        composable(AppRoutes.OfficialYouTubeDemo) {
+                            OfficialYouTubeDemoScreen()
+                        }
+>>>>>>> Stashed changes
                         composable(AppRoutes.Workouts) {
                             WorkoutScreen(navController = navController, workoutViewModel = workoutViewModel)
                         }

--- a/app/src/main/java/com/team2/studentfitness/database/Database.kt
+++ b/app/src/main/java/com/team2/studentfitness/database/Database.kt
@@ -8,7 +8,7 @@ import com.team2.studentfitness.R
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
-@androidx.room.Database(entities = [UserSettings::class, WorkEx::class, Exercises::class, HealthData::class, Workouts::class, MentalHealth::class, MacroLog::class, WorkoutLog::class], version = 6)
+@androidx.room.Database(entities = [UserSettings::class, WorkEx::class, Exercises::class, HealthData::class, Workouts::class, MentalHealth::class, MacroLog::class, WorkoutLog::class], version = 7)
 public abstract class Database : RoomDatabase() {
     abstract fun settingsDao(): SettingsDao
     abstract fun workoutsDao(): WorkoutsDao
@@ -63,6 +63,7 @@ public abstract class Database : RoomDatabase() {
                             val muscleGroup = clean(parts[2])
                             val difficultyStr = clean(parts[3])
                             val description = clean(parts[4])
+                            val videoID = if (parts.size >= 6) clean(parts[5]) else null
 
                             val difficulty = when (difficultyStr.lowercase()) {
                                 "beginner" -> 0
@@ -72,8 +73,8 @@ public abstract class Database : RoomDatabase() {
                             }
 
                             db.execSQL(
-                                "INSERT INTO Exercises (name, muscleGroup, difficulty, description) VALUES (?, ?, ?, ?)",
-                                arrayOf<Any>(name, muscleGroup, difficulty, description)
+                                "INSERT INTO Exercises (name, muscleGroup, difficulty, description, videoID) VALUES (?, ?, ?, ?, ?)",
+                                arrayOf<Any?>(name, muscleGroup, difficulty, description, videoID)
                             )
                         }
                         line = r.readLine()

--- a/app/src/main/java/com/team2/studentfitness/database/Exercises.kt
+++ b/app/src/main/java/com/team2/studentfitness/database/Exercises.kt
@@ -16,6 +16,7 @@ data class Exercises (
     @ColumnInfo(name = "difficulty")
     val difficulty: Int,   //0 = beginner, 1 = intermediate, 2 = advanced
     @ColumnInfo(name = "description")
-    val description: String
+    val description: String,
+    @ColumnInfo(name = "videoID")
+    val videoID: String? = null
 )
-

--- a/app/src/main/java/com/team2/studentfitness/ui/components/youtube/YouTubeEmbedPlayer.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/components/youtube/YouTubeEmbedPlayer.kt
@@ -126,4 +126,3 @@ fun EmbeddedYouTubeVideo(
         onLoadFailed = onLoadFailed
     )
 }
-

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseListScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseListScreen.kt
@@ -22,6 +22,7 @@ import com.team2.studentfitness.DatabaseCreation
 import com.team2.studentfitness.database.Exercises
 import com.team2.studentfitness.database.WorkEx
 import com.team2.studentfitness.database.WorkoutLog
+import com.team2.studentfitness.ui.components.youtube.EmbeddedYouTubeVideo
 import com.team2.studentfitness.ui.theme.Teal
 import com.team2.studentfitness.ui.theme.Orange
 import com.team2.studentfitness.viewmodels.WorkoutViewModel
@@ -181,6 +182,18 @@ fun ExerciseCard(workEx: WorkEx, exercise: Exercises, backgroundColor: Color, te
                 color = textColor.copy(alpha = 0.8f),
                 lineHeight = 18.sp
             )
+
+            exercise.videoID?.let { videoId ->
+                if (videoId.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    EmbeddedYouTubeVideo(
+                        videoId = videoId,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f)
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseSelectionScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/ExerciseSelectionScreen.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.team2.studentfitness.DatabaseCreation
 import com.team2.studentfitness.database.Exercises
+import com.team2.studentfitness.ui.components.youtube.EmbeddedYouTubeVideo
 import com.team2.studentfitness.ui.theme.Teal
 import com.team2.studentfitness.viewmodels.WorkoutViewModel
 
@@ -123,32 +124,47 @@ fun SelectionExerciseCard(
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
         border = if (isSelected) androidx.compose.foundation.BorderStroke(2.dp, Color(0xFFF7A643)) else null
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = exercise.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = textColor
-                )
-                Text(
-                    text = exercise.description,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = textColor.copy(alpha = 0.7f),
-                    maxLines = 2
-                )
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = exercise.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = textColor
+                    )
+                }
+                
+                IconButton(onClick = onSelect) {
+                    Icon(
+                        imageVector = if (isSelected) Icons.Default.Check else Icons.Default.Add,
+                        contentDescription = if (isSelected) "Selected" else "Add",
+                        tint = if (isSelected) Color(0xFFF7A643) else textColor.copy(alpha = 0.5f)
+                    )
+                }
             }
-            
-            IconButton(onClick = onSelect) {
-                Icon(
-                    imageVector = if (isSelected) Icons.Default.Check else Icons.Default.Add,
-                    contentDescription = if (isSelected) "Selected" else "Add",
-                    tint = if (isSelected) Color(0xFFF7A643) else textColor.copy(alpha = 0.5f)
-                )
+
+            Text(
+                text = exercise.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = textColor.copy(alpha = 0.7f),
+                maxLines = 3
+            )
+
+            exercise.videoID?.let { videoId ->
+                if (videoId.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    EmbeddedYouTubeVideo(
+                        videoId = videoId,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/raw/exercise.csv
+++ b/app/src/main/res/raw/exercise.csv
@@ -1,81 +1,81 @@
-ID,Name,MuscleGroup,DifficultyLevel,Description
-E001,Barbell Bench Press,Chest,Intermediate,"Set feet flat and shoulder blades pulled back, lower the bar to mid-chest with elbows about 45 degrees, then press up while keeping wrists stacked and glutes on the bench."
-E002,Dumbbell Bench Press,Chest,Intermediate,"Plant feet, keep shoulder blades pinned, lower dumbbells under control to chest level, and press up evenly without letting wrists bend back or elbows flare hard."
-E003,Incline Dumbbell Press,Chest,Intermediate,"Set bench at 30-45 degrees, brace core, lower dumbbells to upper-chest line with forearms vertical, then press smoothly without arching your lower back."
-E004,Chest Fly (Dumbbell),Chest,Beginner,"Keep a slight elbow bend, open arms in a wide arc until chest feels a stretch, then squeeze back up with control while shoulders stay down and back."
-E005,Push-Ups,Chest,Beginner,"Start in a straight plank, lower chest between hands with elbows angled back, and press up while keeping hips level, neck neutral, and core tight."
-E006,Cable Chest Fly,Chest,Beginner,"Stand staggered and braced, bring handles together in a hugging arc, pause at center, and return slowly without shrugging or overextending shoulders."
-E007,Pull-Ups,Back,Advanced,"Hang with active shoulders, brace core, pull elbows toward ribs until chin clears the bar, and lower fully under control without swinging or kipping."
-E008,Lat Pulldown,Back,Beginner,"Sit tall with chest up, pull bar to upper chest by driving elbows down, and return slowly to full stretch without leaning far back or yanking."
-E009,Barbell Row,Back,Intermediate,"Hinge at hips with flat back, keep bar close, row toward lower ribs, and lower under control while maintaining a fixed torso and braced core."
-E010,Dumbbell Row,Back,Beginner,"Support your torso, keep spine neutral, pull elbow toward hip, and lower slowly while avoiding torso twist or shoulder shrug on each rep."
-E011,Seated Cable Row,Back,Beginner,"Sit tall with slight knee bend, pull handle to lower ribs by squeezing shoulder blades, then extend arms smoothly without rounding your back."
-E012,Face Pull,Back,Beginner,"Set cable at face height, pull rope toward nose with elbows high, rotate hands outward, and control the return while keeping ribs down."
-E013,T-Bar Row,Back,Intermediate,"Hinge with neutral spine and soft knees, pull handle to chest by driving elbows back, and lower with control without jerking from the lower back."
-E014,Inverted Row,Back,Beginner,"Keep body in a straight line, pull chest to bar by retracting shoulder blades, and lower fully with control without hips sagging."
-E015,Overhead Barbell Press,Shoulders,Intermediate,"Start with bar at upper chest, squeeze glutes and core, press straight overhead so biceps finish by ears, and lower under control without leaning back."
-E016,Dumbbell Shoulder Press,Shoulders,Beginner,"Sit or stand tall, press dumbbells overhead on a vertical path, and lower to shoulder level while keeping wrists neutral and core braced."
-E017,Lateral Raises,Shoulders,Beginner,"Raise arms out to shoulder height with soft elbows and thumbs slightly up, then lower slowly while keeping traps relaxed and torso still."
-E018,Front Raises,Shoulders,Beginner,"Lift weight to shoulder height with controlled tempo, keep ribs down and elbows soft, and avoid using body swing to start reps."
-E019,Rear Delt Fly,Shoulders,Beginner,"Hinge with flat back, raise arms out and slightly back from shoulders, pause briefly, and lower slowly without neck tension or momentum."
-E020,Arnold Press,Shoulders,Intermediate,"Start palms facing in at chin level, rotate and press overhead in one smooth path, then reverse slowly while keeping core tight and back neutral."
-E021,Barbell Curl,Biceps,Beginner,"Stand tall with elbows near sides, curl bar without swinging, squeeze at top, and lower fully under control while keeping wrists straight."
-E022,Dumbbell Curl,Biceps,Beginner,"Keep shoulders down and elbows fixed, curl with palms rotating up, and lower slowly to full extension without leaning back."
-E023,Hammer Curl,Biceps,Beginner,"Hold neutral grip, curl by bending elbows only, and lower with control while keeping upper arms still and posture upright."
-E024,Preacher Curl,Biceps,Beginner,"Set upper arms firmly on pad, curl through full range without lifting elbows, and lower slowly to maintain constant tension and joint control."
-E025,Tricep Dips,Triceps,Intermediate,"Grip bars with shoulders down, lower until elbows reach about 90 degrees, then press up without locking hard or letting shoulders roll forward."
-E026,Skull Crushers,Triceps,Intermediate,"Keep upper arms mostly vertical, bend elbows to lower weight near forehead, and extend back up smoothly without flaring elbows wide."
-E027,Cable Tricep Pushdown,Triceps,Beginner,"Pin elbows to sides, press handle down until arms are straight, pause briefly, and return slowly without shoulder movement or torso sway."
-E028,Overhead Tricep Extension,Triceps,Beginner,"Keep elbows pointed forward, lower weight behind head with control, and extend up while bracing core and avoiding lower-back arch."
-E029,Barbell Squat,Quads,Advanced,"Set bar across upper back, brace and sit down between hips with knees tracking toes, then drive up through mid-foot while keeping chest and spine stable."
-E030,Goblet Squat,Quads,Beginner,"Hold weight at chest, keep heels down and torso tall, descend until hips are below or near knee level, then stand by pushing knees out and hips through."
-E031,Leg Press,Quads,Beginner,"Place feet shoulder-width on platform, lower sled until knees are deeply bent but controlled, and press up without locking knees or lifting hips."
-E032,Walking Lunges,Quads,Intermediate,"Step long enough for both knees to bend about 90 degrees, keep torso upright, and push through front heel to move forward under control."
-E033,Bulgarian Split Squat,Quads,Intermediate,"Set rear foot on bench, keep front knee tracking over toes, lower straight down with slight forward torso lean, and drive up through front leg."
-E034,Step-Ups,Quads,Beginner,"Place full foot on box, lean slightly forward, drive through lead heel to stand tall, and step down softly without pushing off trailing leg."
-E035,Jump Squats,Quads,Advanced,"Squat with knees aligned over toes, explode upward with full hip extension, and land softly into the next rep with controlled knee and hip bend."
-E036,Wall Sit,Quads,Beginner,"Slide down until knees are near 90 degrees, keep back and head against wall, and hold with even foot pressure and steady breathing."
-E037,Romanian Deadlift,Hamstrings,Intermediate,"Hinge hips back with soft knees, keep bar close to thighs and spine neutral, lower until hamstrings stretch, then drive hips forward to stand."
-E038,Conventional Deadlift,Hamstrings,Advanced,"Set bar over mid-foot, brace, pull slack from bar, and stand by pushing floor away while keeping bar close and back neutral throughout."
-E039,Hip Thrust,Glutes,Intermediate,"Rest upper back on bench, tuck chin slightly, drive through heels to lift hips until torso is parallel, then lower under control without overarching."
-E040,Hamstring Curl,Hamstrings,Beginner,"Align knees with machine pivot, curl pad toward glutes without lifting hips, and lower slowly to full extension for controlled reps."
-E041,Glute Bridge,Glutes,Beginner,"Lie with feet hip-width and close to glutes, brace core, lift hips by squeezing glutes, and lower slowly without letting knees cave inward."
-E042,Kettlebell Swing,Hamstrings,Intermediate,"Hinge not squat, hike bell back, snap hips forward to chest height, and let bell return naturally while keeping back flat and shoulders packed."
-E043,Plank,Core,Beginner,"Stack shoulders over elbows, squeeze glutes and abs, keep body straight from head to heels, and breathe steadily without hips dropping or piking."
-E044,Side Plank,Core,Beginner,"Elbow under shoulder, hips lifted in one straight line, and hold while keeping neck neutral and top shoulder stacked over bottom shoulder."
-E045,Bicycle Crunch,Core,Beginner,"Keep low back lightly pressed down, rotate ribcage to opposite knee, and move slowly with full exhale each twist instead of pulling on neck."
-E046,Leg Raises,Core,Intermediate,"Keep lower back anchored, raise legs with controlled tempo, and lower only as far as you can maintain core tension without arching."
-E047,Russian Twist,Core,Beginner,"Sit tall with slight lean, brace core, rotate torso side to side from ribs, and keep movement controlled without rounding lower back."
-E048,Hanging Leg Raise,Core,Advanced,"Start from active hang, brace and lift legs by tilting pelvis up, pause briefly, and lower slowly without swinging."
-E049,Ab Wheel Rollout,Core,Advanced,"Brace abs and glutes, roll forward while keeping ribs tucked and back neutral, then pull back using core without letting hips sag."
-E050,Mountain Climbers,Cardio,Beginner,"Start in strong plank, drive one knee at a time toward chest, and keep shoulders stacked and hips level at a smooth, quick pace."
-E051,Burpees,Cardio,Intermediate,"Squat to floor with neutral spine, jump feet back to plank, return feet under hips, and jump up softly while keeping reps controlled."
-E052,Jump Rope,Cardio,Beginner,"Keep elbows close and rotate rope from wrists, jump low on balls of feet, and land softly with relaxed shoulders and steady rhythm."
-E053,High Knees,Cardio,Beginner,"Run tall with quick contacts, drive knees to hip height, pump arms naturally, and land under hips to reduce impact stress."
-E054,Sprint Intervals,Cardio,Advanced,"Warm up well, keep slight forward lean and active arm drive during sprints, then walk or jog recovery while maintaining clean mechanics."
-E055,Rowing Machine,Cardio,Beginner,"Sequence each stroke legs then hips then arms, return arms then hips then legs, and keep spine long without rounding at the catch."
-E056,Treadmill Run,Cardio,Beginner,"Run tall with slight forward lean from ankles, land under center of mass, and keep cadence steady without overstriding."
-E057,Cycling,Cardio,Beginner,"Set saddle for slight knee bend at bottom stroke, keep core engaged and shoulders relaxed, and pedal in smooth circles with stable hips."
-E058,Stair Climber,Cardio,Intermediate,"Stand upright with light hand support, place full foot on each step, and drive through heel while keeping knees aligned and pace consistent."
-E059,Battle Ropes,Full Body,Intermediate,"Set athletic stance with soft knees, brace core, create waves from shoulders and arms together, and keep spine neutral as tempo rises."
-E060,Medicine Ball Slams,Full Body,Intermediate,"Lift ball overhead with ribs down, slam by hinging and driving arms down forcefully, then catch safely with bent knees and neutral back."
-E061,Farmer's Carry,Full Body,Beginner,"Stand tall with weights at sides, pack shoulders down, take short controlled steps, and keep core braced without leaning or shrugging."
-E062,Sled Push,Full Body,Intermediate,"Lean slightly into sled with straight line from head to heel, drive knees forward in quick steps, and keep core tight throughout push."
-E063,Box Jumps,Full Body,Intermediate,"Use a quarter squat, swing arms and jump with both feet, land softly in athletic stance, then step down to reduce impact fatigue."
-E064,Agility Ladder Drills,Full Body,Beginner,"Stay on balls of feet with slight knee bend, use quick precise steps, and keep torso quiet while increasing speed gradually."
-E065,Tire Flips,Full Body,Advanced,"Set hips low with flat back, drive through legs to lift tire, then transition hands to push it over while keeping core braced."
-E066,Dynamic Stretch Circuit,Mobility,Beginner,"Move joints through controlled full ranges, keep breathing steady, and avoid bouncing or forcing end ranges during each drill."
-E067,Foam Rolling,Mobility,Beginner,"Roll slowly over tight areas, pause on tender spots for 20-30 seconds, and breathe deeply without rolling directly over joints."
-E068,Hip Flexor Stretch,Mobility,Beginner,"From half-kneel, tuck pelvis slightly and squeeze rear glute, then shift forward gently until front hip stretches without lower-back arch."
-E069,Hamstring Stretch,Mobility,Beginner,"Keep spine long and hinge at hips toward straight leg, stop at mild tension, and breathe slowly without rounding aggressively."
-E070,Shoulder Mobility Band Work,Mobility,Beginner,"Use light band tension, move shoulders through pain-free range with controlled tempo, and keep ribs down to avoid compensating through the back."
-E071,Pec Deck,Chest,Beginner,"Set seat so handles align with mid-chest, keep elbows slightly bent, bring arms together smoothly, and return slowly without shoulder shrugging."
-E072,Assisted Pull-Up,Back,Beginner,"Use enough assistance for full range, start from active hang, pull chest toward bar with elbows down, and lower under control each rep."
-E073,Smith Machine Squat,Quads,Beginner,"Set feet slightly ahead of bar path, brace core, squat to controlled depth with knees tracking toes, and stand without collapsing inward."
-E074,Leg Extension,Quads,Beginner,"Align knee joint with machine pivot, extend legs to near straight, pause briefly, and lower slowly without swinging or snapping knees."
-E075,Calf Raises,Calves,Beginner,"Press through big toe and ball of foot to rise fully, pause at top, and lower through full stretch with controlled ankle alignment."
-E076,Cable Woodchopper,Core,Intermediate,"Rotate through torso and hips together, keep arms mostly extended, and control both pull and return without twisting the lower back aggressively."
-E077,Power Clean,Full Body,Advanced,"Set neutral spine, push from legs, keep bar close through explosive hip extension, and catch on shoulders with elbows high and stable feet."
-E078,Snatch,Full Body,Advanced,"Start with wide grip and braced trunk, drive powerfully through hips, pull under fast, and receive overhead with locked elbows and stable core."
-E079,Push Press,Shoulders,Intermediate,"Dip straight down with upright torso, drive through legs to launch bar, then press to lockout while keeping ribs down and head through."
-E080,Depth Jumps,Full Body,Advanced,"Step off box under control, absorb landing with hips and knees aligned, then rebound quickly upward with minimal ground contact and soft mechanics."
+ID,Name,MuscleGroup,DifficultyLevel,Description,VideoID
+E001,Barbell Bench Press,Chest,Intermediate,"Set feet flat and shoulder blades pulled back, lower the bar to mid-chest with elbows about 45 degrees, then press up while keeping wrists stacked and glutes on the bench.",WsRokhYnkR4
+E002,Dumbbell Bench Press,Chest,Intermediate,"Plant feet, keep shoulder blades pinned, lower dumbbells under control to chest level, and press up evenly without letting wrists bend back or elbows flare hard.",putt5zl7Rjk
+E003,Incline Dumbbell Press,Chest,Intermediate,"Set bench at 30-45 degrees, brace core, lower dumbbells to upper-chest line with forearms vertical, then press smoothly without arching your lower back.",1xjD8p4pyqE
+E004,Chest Fly (Dumbbell),Chest,Beginner,"Keep a slight elbow bend, open arms in a wide arc until chest feels a stretch, then squeeze back up with control while shoulders stay down and back.",C4qqdw1qvhY
+E005,Push-Ups,Chest,Beginner,"Start in a straight plank, lower chest between hands with elbows angled back, and press up while keeping hips level, neck neutral, and core tight.",Xdzfcn2XgNs
+E006,Cable Chest Fly,Chest,Beginner,"Stand staggered and braced, bring handles together in a hugging arc, pause at center, and return slowly without shrugging or overextending shoulders.",AC-RR3xPAHU
+E007,Pull-Ups,Back,Advanced,"Hang with active shoulders, brace core, pull elbows toward ribs until chin clears the bar, and lower fully under control without swinging or kipping.",bMqaIoJompM
+E008,Lat Pulldown,Back,Beginner,"Sit tall with chest up, pull bar to upper chest by driving elbows down, and return slowly to full stretch without leaning far back or yanking.",RpNZNtFDpI4
+E009,Barbell Row,Back,Intermediate,"Hinge at hips with flat back, keep bar close, row toward lower ribs, and lower under control while maintaining a fixed torso and braced core.",CUB-tz0idJw
+E010,Dumbbell Row,Back,Beginner,"Support your torso, keep spine neutral, pull elbow toward hip, and lower slowly while avoiding torso twist or shoulder shrug on each rep.",Q7utTm7eTIA
+E011,Seated Cable Row,Back,Beginner,"Sit tall with slight knee bend, pull handle to lower ribs by squeezing shoulder blades, then extend arms smoothly without rounding your back.",YKAeU55CkVk
+E012,Face Pull,Back,Beginner,"Set cable at face height, pull rope toward nose with elbows high, rotate hands outward, and control the return while keeping ribs down.",rep-qVOkqgk
+E013,T-Bar Row,Back,Intermediate,"Hinge with neutral spine and soft knees, pull handle to chest by driving elbows back, and lower with control without jerking from the lower back.",AMyF-aXCX3U
+E014,Inverted Row,Back,Beginner,"Keep body in a straight line, pull chest to bar by retracting shoulder blades, and lower fully with control without hips sagging.",x8WGYnzyTtk
+E015,Overhead Barbell Press,Shoulders,Intermediate,"Start with bar at upper chest, squeeze glutes and core, press straight overhead so biceps finish by ears, and lower under control without leaning back.",cm42MyP163o
+E016,Dumbbell Shoulder Press,Shoulders,Beginner,"Sit or stand tall, press dumbbells overhead on a vertical path, and lower to shoulder level while keeping wrists neutral and core braced.",IgC8EGv6qyQ
+E017,Lateral Raises,Shoulders,Beginner,"Raise arms out to shoulder height with soft elbows and thumbs slightly up, then lower slowly while keeping traps relaxed and torso still.",5SV3vxP5LAg
+E018,Front Raises,Shoulders,Beginner,"Lift weight to shoulder height with controlled tempo, keep ribs down and elbows soft, and avoid using body swing to start reps.",mOXz11Fo2r0
+E019,Rear Delt Fly,Shoulders,Beginner,"Hinge with flat back, raise arms out and slightly back from shoulders, pause briefly, and lower slowly without neck tension or momentum.",DnjylCBxedQ
+E020,Arnold Press,Shoulders,Intermediate,"Start palms facing in at chin level, rotate and press overhead in one smooth path, then reverse slowly while keeping core tight and back neutral.",2lls46DE5R0
+E021,Barbell Curl,Biceps,Beginner,"Stand tall with elbows near sides, curl bar without swinging, squeeze at top, and lower fully under control while keeping wrists straight.",TSLvcSVxJ58
+E022,Dumbbell Curl,Biceps,Beginner,"Keep shoulders down and elbows fixed, curl with palms rotating up, and lower slowly to full extension without leaning back.",D0bTUapH35M
+E023,Hammer Curl,Biceps,Beginner,"Hold neutral grip, curl by bending elbows only, and lower with control while keeping upper arms still and posture upright.",9VjSDuDBGTc
+E024,Preacher Curl,Biceps,Beginner,"Set upper arms firmly on pad, curl through full range without lifting elbows, and lower slowly to maintain constant tension and joint control.",ylLaT55wAKM
+E025,Tricep Dips,Triceps,Intermediate,"Grip bars with shoulders down, lower until elbows reach about 90 degrees, then press up without locking hard or letting shoulders roll forward.",8IE75-AT_rk
+E026,Skull Crushers,Triceps,Intermediate,"Keep upper arms mostly vertical, bend elbows to lower weight near forehead, and extend back up smoothly without flaring elbows wide.",2gYQv-ukYRI
+E027,Cable Tricep Pushdown,Triceps,Beginner,"Pin elbows to sides, press handle down until arms are straight, pause briefly, and return slowly without shoulder movement or torso sway.",AQ1PC029lrQ
+E028,Overhead Tricep Extension,Triceps,Beginner,"Keep elbows pointed forward, lower weight behind head with control, and extend up while bracing core and avoiding lower-back arch.",PJri9EcEW34
+E029,Barbell Squat,Quads,Advanced,"Set bar across upper back, brace and sit down between hips with knees tracking toes, then drive up through mid-foot while keeping chest and spine stable.",wCchUJM8_ls
+E030,Goblet Squat,Quads,Beginner,"Hold weight at chest, keep heels down and torso tall, descend until hips are below or near knee level, then stand by pushing knees out and hips through.",x-vLXZ_s5iA
+E031,Leg Press,Quads,Beginner,"Place feet shoulder-width on platform, lower sled until knees are deeply bent but controlled, and press up without locking knees or lifting hips.",bYa0zSOXj28
+E032,Walking Lunges,Quads,Intermediate,"Step long enough for both knees to bend about 90 degrees, keep torso upright, and push through front heel to move forward under control.",NlYoEc4HCZQ
+E033,Bulgarian Split Squat,Quads,Intermediate,"Set rear foot on bench, keep front knee tracking over toes, lower straight down with slight forward torso lean, and drive up through front leg.",3APY3yIvWgw
+E034,Step-Ups,Quads,Beginner,"Place full foot on box, lean slightly forward, drive through lead heel to stand tall, and step down softly without pushing off trailing leg.",eKb_iC3ebSg
+E035,Jump Squats,Quads,Advanced,"Squat with knees aligned over toes, explode upward with full hip extension, and land softly into the next rep with controlled knee and hip bend.",-pgemtEZcx4
+E036,Wall Sit,Quads,Beginner,"Slide down until knees are near 90 degrees, keep back and head against wall, and hold with even foot pressure and steady breathing.",cyjX6UDqDYc
+E037,Romanian Deadlift,Hamstrings,Intermediate,"Hinge hips back with soft knees, keep bar close to thighs and spine neutral, lower until hamstrings stretch, then drive hips forward to stand.",JuimVqermb4
+E038,Conventional Deadlift,Hamstrings,Advanced,"Set bar over mid-foot, brace, pull slack from bar, and stand by pushing floor away while keeping bar close and back neutral throughout.",SgbGWuoZ7Bc
+E039,Hip Thrust,Glutes,Intermediate,"Rest upper back on bench, tuck chin slightly, drive through heels to lift hips until torso is parallel, then lower under control without overarching.",G-cvFx46QNM
+E040,Hamstring Curl,Hamstrings,Beginner,"Align knees with machine pivot, curl pad toward glutes without lifting hips, and lower slowly to full extension for controlled reps.",2LHNJGMfnxk
+E041,Glute Bridge,Glutes,Beginner,"Lie with feet hip-width and close to glutes, brace core, lift hips by squeezing glutes, and lower slowly without letting knees cave inward.",PqUJgUL2vB0
+E042,Kettlebell Swing,Hamstrings,Intermediate,"Hinge not squat, hike bell back, snap hips forward to chest height, and let bell return naturally while keeping back flat and shoulders packed.",uI8ES4jRcPk
+E043,Plank,Core,Beginner,"Stack shoulders over elbows, squeeze glutes and abs, keep body straight from head to heels, and breathe steadily without hips dropping or piking.",3ECmYz2qxCQ
+E044,Side Plank,Core,Beginner,"Elbow under shoulder, hips lifted in one straight line, and hold while keeping neck neutral and top shoulder stacked over bottom shoulder.",87KrEomlo-c
+E045,Bicycle Crunch,Core,Beginner,"Keep low back lightly pressed down, rotate ribcage to opposite knee, and move slowly with full exhale each twist instead of pulling on neck.",mgrEuFPj6-o
+E046,Leg Raises,Core,Intermediate,"Keep lower back anchored, raise legs with controlled tempo, and lower only as far as you can maintain core tension without arching.",RqAI53juIb4
+E047,Russian Twist,Core,Beginner,"Sit tall with slight lean, brace core, rotate torso side to side from ribs, and keep movement controlled without rounding lower back.",Evsux3PWHEA
+E048,Hanging Leg Raise,Core,Advanced,"Start from active hang, brace and lift legs by tilting pelvis up, pause briefly, and lower slowly without swinging.",O6KGBYAzjzo
+E049,Ab Wheel Rollout,Core,Advanced,"Brace abs and glutes, roll forward while keeping ribs tucked and back neutral, then pull back using core without letting hips sag.",twUBthC0v1U
+E050,Mountain Climbers,Cardio,Beginner,"Start in strong plank, drive one knee at a time toward chest, and keep shoulders stacked and hips level at a smooth, quick pace.",_AiJDOMklV8
+E051,Burpees,Cardio,Intermediate,"Squat to floor with neutral spine, jump feet back to plank, return feet under hips, and jump up softly while keeping reps controlled.",b8-oTMeOrTI
+E052,Jump Rope,Cardio,Beginner,"Keep elbows close and rotate rope from wrists, jump low on balls of feet, and land softly with relaxed shoulders and steady rhythm.",o0snL3Yg6FI
+E053,High Knees,Cardio,Beginner,"Run tall with quick contacts, drive knees to hip height, pump arms naturally, and land under hips to reduce impact stress.",yvdnZkzeOOI
+E054,Sprint Intervals,Cardio,Advanced,"Warm up well, keep slight forward lean and active arm drive during sprints, then walk or jog recovery while maintaining clean mechanics.",7UPV0WEbQ4o
+E055,Rowing Machine,Cardio,Beginner,"Sequence each stroke legs then hips then arms, return arms then hips then legs, and keep spine long without rounding at the catch.",TbYgwYlfRDs
+E056,Treadmill Run,Cardio,Beginner,"Run tall with slight forward lean from ankles, land under center of mass, and keep cadence steady without overstriding.",7UPV0WEbQ4o
+E057,Cycling,Cardio,Beginner,"Set saddle for slight knee bend at bottom stroke, keep core engaged and shoulders relaxed, and pedal in smooth circles with stable hips.",VuLPY1VBzHc
+E058,Stair Climber,Cardio,Intermediate,"Stand upright with light hand support, place full foot on each step, and drive through heel while keeping knees aligned and pace consistent.",GPpmygCGRCU
+E059,Battle Ropes,Full Body,Intermediate,"Set athletic stance with soft knees, brace core, create waves from shoulders and arms together, and keep spine neutral as tempo rises.",7UZFoz010FY
+E060,Medicine Ball Slams,Full Body,Intermediate,"Lift ball overhead with ribs down, slam by hinging and driving arms down forcefully, then catch safely with bent knees and neutral back.",l4pNQQs8uaQ
+E061,Farmer's Carry,Full Body,Beginner,"Stand tall with weights at sides, pack shoulders down, take short controlled steps, and keep core braced without leaning or shrugging.",QXiqSDo_YiM
+E062,Sled Push,Full Body,Intermediate,"Lean slightly into sled with straight line from head to heel, drive knees forward in quick steps, and keep core tight throughout push.",QwscR2BhdEg
+E063,Box Jumps,Full Body,Intermediate,"Use a quarter squat, swing arms and jump with both feet, land softly in athletic stance, then step down to reduce impact fatigue.",winTXKH1l6M
+E064,Agility Ladder Drills,Full Body,Beginner,"Stay on balls of feet with slight knee bend, use quick precise steps, and keep torso quiet while increasing speed gradually.",66oUAhI0nQQ
+E065,Tire Flips,Full Body,Advanced,"Set hips low with flat back, drive through legs to lift tire, then transition hands to push it over while keeping core braced.",uIw9920WtXE
+E066,Dynamic Stretch Circuit,Mobility,Beginner,"Move joints through controlled full ranges, keep breathing steady, and avoid bouncing or forcing end ranges during each drill.",LwVD8_khhhY
+E067,Foam Rolling,Mobility,Beginner,"Roll slowly over tight areas, pause on tender spots for 20-30 seconds, and breathe deeply without rolling directly over joints.",Ncl0oa4pD-8
+E068,Hip Flexor Stretch,Mobility,Beginner,"From half-kneel, tuck pelvis slightly and squeeze rear glute, then shift forward gently until front hip stretches without lower-back arch.",DXuStgWuJV8
+E069,Hamstring Stretch,Mobility,Beginner,"Keep spine long and hinge at hips toward straight leg, stop at mild tension, and breathe slowly without rounding aggressively.",GUCvjixKVi
+E070,Shoulder Mobility Band Work,Mobility,Beginner,"Use light band tension, move shoulders through pain-free range with controlled tempo, and keep ribs down to avoid compensating through the back.",Annb0cpxwzM
+E071,Pec Deck,Chest,Beginner,"Set seat so handles align with mid-chest, keep elbows slightly bent, bring arms together smoothly, and return slowly without shoulder shrugging.",-IAPoWUZNTo
+E072,Assisted Pull-Up,Back,Beginner,"Use enough assistance for full range, start from active hang, pull chest toward bar with elbows down, and lower under control each rep.",bxb1xZN7LJU
+E073,Smith Machine Squat,Quads,Beginner,"Set feet slightly ahead of bar path, brace core, squat to controlled depth with knees tracking toes, and stand without collapsing inward.",ZUyre1II1ds
+E074,Leg Extension,Quads,Beginner,"Align knee joint with machine pivot, extend legs to near straight, pause briefly, and lower slowly without swinging or snapping knees.",-I4VjXaY800
+E075,Calf Raises,Calves,Beginner,"Press through big toe and ball of foot to rise fully, pause at top, and lower through full stretch with controlled ankle alignment.",I7ujdec8b64
+E076,Cable Woodchopper,Core,Intermediate,"Rotate through torso and hips together, keep arms mostly extended, and control both pull and return without twisting the lower back aggressively.",OaQ5v7f6Hw0
+E077,Power Clean,Full Body,Advanced,"Set neutral spine, push from legs, keep bar close through explosive hip extension, and catch on shoulders with elbows high and stable feet.",coUQu9xQOAw
+E078,Snatch,Full Body,Advanced,"Start with wide grip and braced trunk, drive powerfully through hips, pull under fast, and receive overhead with locked elbows and stable core.",xFYjovfraZ0
+E079,Push Press,Shoulders,Intermediate,"Dip straight down with upright torso, drive through legs to launch bar, then press to lockout while keeping ribs down and head through.",zLJhOevTQzs
+E080,Depth Jumps,Full Body,Advanced,"Step off box under control, absorb landing with hips and knees aligned, then rebound quickly upward with minimal ground contact and soft mechanics.",dkthVHrGYUI


### PR DESCRIPTION
This pull request adds support for associating YouTube video demonstrations with exercises in the app. It updates the database schema to store a `videoID` for each exercise, modifies the data model and database initialization logic, and updates the UI to display embedded YouTube videos for exercises that have an associated video. Additionally, it introduces new navigation routes for video demo screens.

**Database and Data Model Enhancements:**

* Added a nullable `videoID` field to the `Exercises` entity and updated the database schema version to 7 to support storing YouTube video IDs for exercises. The database initialization logic now reads and stores this field when available. [[1]](diffhunk://#diff-5a08884fe621d94e8c0028391d21ad622d1feed65f8ce5615d635a210eb23a3fL11-R11) [[2]](diffhunk://#diff-42e55a8972c56ca04bd6004a962956c9e802f7138652caf84db2a6bcb1e15dd2L19-L21) [[3]](diffhunk://#diff-5a08884fe621d94e8c0028391d21ad622d1feed65f8ce5615d635a210eb23a3fR66) [[4]](diffhunk://#diff-5a08884fe621d94e8c0028391d21ad622d1feed65f8ce5615d635a210eb23a3fL75-R77)

**UI Updates for Embedded Videos:**

* Updated the `ExerciseListScreen` and `ExerciseSelectionScreen` to display embedded YouTube videos using the new `EmbeddedYouTubeVideo` component when an exercise has a valid `videoID`. The exercise description and video are now shown together in the selection card. [[1]](diffhunk://#diff-e060493f2b44d5d3de0f282a35cc6f87e7213cd7625fe2c926ff7049aaa4a83dR25) [[2]](diffhunk://#diff-e060493f2b44d5d3de0f282a35cc6f87e7213cd7625fe2c926ff7049aaa4a83dR185-R196) [[3]](diffhunk://#diff-53fdd75acc1d79299289f7954588224c45e03a7b9b5bb5adcd9001cf996ae269R26) [[4]](diffhunk://#diff-53fdd75acc1d79299289f7954588224c45e03a7b9b5bb5adcd9001cf996ae269R127-R129) [[5]](diffhunk://#diff-53fdd75acc1d79299289f7954588224c45e03a7b9b5bb5adcd9001cf996ae269L138-L143) [[6]](diffhunk://#diff-53fdd75acc1d79299289f7954588224c45e03a7b9b5bb5adcd9001cf996ae269R150-R169)

**Navigation Improvements:**

* Added new navigation routes and composable screens for `VideoDemo` and `OfficialYouTubeDemo` to support dedicated video demo pages.