### PR TITLE
114 kubernetes set up

### DIFF
--- a/README.kubernetes.md
+++ b/README.kubernetes.md
@@ -24,11 +24,31 @@ From the repository root:
 docker build -t student-fitness-android:local .
 ```
 
-If using a local cluster, load that image into the cluster runtime (example for minikube):
+If using a local cluster, load that image into the cluster runtime.
 
+**minikube:**
 ```bash
 minikube image load student-fitness-android:local
 ```
+
+**kind** (Kubernetes in Docker):
+
+First, make sure the `kind` CLI is installed. If it is not:
+- **Windows:** Download the binary from https://kind.sigs.k8s.io/dl/latest/kind-windows-amd64 and place it in a directory on your `PATH` (e.g. `C:\Windows\System32\kind.exe`), or install via Chocolatey: `choco install kind`
+- **macOS:** `brew install kind`
+- **Linux:** `go install sigs.k8s.io/kind@latest` or download from the releases page
+
+Then load the image into all kind nodes. If your cluster is the default unnamed cluster:
+```bash
+kind load docker-image student-fitness-android:local
+```
+
+If your cluster has a name (check with `kind get clusters`):
+```bash
+kind load docker-image student-fitness-android:local --name <cluster-name>
+```
+
+> **Note:** `kind load docker-image` must be re-run every time you rebuild the image, because kind nodes have their own isolated container runtime separate from your local Docker daemon.
 
 ## 2) Apply Kubernetes resources
 

--- a/README.kubernetes.md
+++ b/README.kubernetes.md
@@ -132,7 +132,14 @@ kubectl apply -f kubernetes/
 
 - `build-artifacts-pvc` stores Gradle build outputs and reports shared across Jobs.
 - `build-artifacts-pvc` uses `ReadWriteOnce` for broad storage-class compatibility, so run the Jobs one at a time.
-- `emulator-data-pvc` persists emulator data (`/home/androidusr`) across pod restarts.
+- `emulator-data-pvc` persists emulator AVD data (`/home/androidusr/.android`) across pod restarts.
+  > **Note:** Unlike Docker named volumes, Kubernetes PVCs start empty and do **not** inherit the container's existing directory contents on first use. For this reason the PVC is mounted at `/home/androidusr/.android` (the AVD state directory) rather than the top-level `/home/androidusr`, which would shadow the startup scripts shipped inside the image and cause a `CrashLoopBackOff`. If you previously applied `emulator.yaml` with the old mount path, delete and recreate the `emulator-data-pvc` PVC and the emulator Deployment before re-applying:
+  > ```bash
+  > kubectl delete deployment emulator -n student-fitness
+  > kubectl delete pvc emulator-data-pvc -n student-fitness
+  > kubectl apply -f kubernetes/persistent-volume-claims.yaml
+  > kubectl apply -f kubernetes/emulator.yaml
+  > ```
 - If you need to re-run Jobs, delete the previous Job resource first:
 
 ```bash

--- a/README.kubernetes.md
+++ b/README.kubernetes.md
@@ -77,9 +77,12 @@ kubectl logs -n student-fitness job/run-unit-tests -f
 After the emulator is running and the build job has completed:
 
 ```bash
+kubectl delete job install-apk -n student-fitness --ignore-not-found
 kubectl apply -f kubernetes/install-job.yaml
 kubectl logs -n student-fitness job/install-apk -f
 ```
+
+> **Important:** Always delete the old `install-apk` Job before re-applying. Kubernetes Jobs are immutable once created — if the Job already exists, `kubectl apply` will report `unchanged` and no new pod will run. The `--ignore-not-found` flag makes the delete safe to run even when no prior Job exists, and works on Windows, macOS, and Linux.
 
 ## Accessing the emulator UI
 
@@ -143,5 +146,21 @@ kubectl apply -f kubernetes/
 - If you need to re-run Jobs, delete the previous Job resource first:
 
 ```bash
-kubectl delete job build-apk run-unit-tests install-apk -n student-fitness
+kubectl delete job build-apk run-unit-tests install-apk -n student-fitness --ignore-not-found
 ```
+
+### `kubectl apply` says `unchanged` and the app is not installed
+
+This means the `install-apk` Job already existed from a previous run. Kubernetes Jobs are immutable — `kubectl apply` will not create a new pod if the Job spec has not changed.
+
+**What happened:** The old job's logs are shown by `kubectl logs`, making it appear the install succeeded. But if the emulator pod was restarted since that old run, the app is no longer installed.
+
+**Fix:** Delete the old job first, then re-apply:
+
+```bat
+kubectl delete job install-apk -n student-fitness --ignore-not-found
+kubectl apply -f kubernetes/install-job.yaml
+kubectl logs -n student-fitness job/install-apk -f
+```
+
+> **Windows note:** Do not use `2>/dev/null || true` — that is bash syntax and does not work in Command Prompt or PowerShell. Use `--ignore-not-found` instead, which is a native `kubectl` flag and works on all platforms.

--- a/README.kubernetes.md
+++ b/README.kubernetes.md
@@ -1,0 +1,83 @@
+# Kubernetes Setup — Student Fitness App
+
+This setup mirrors the existing Docker Compose workflow with Kubernetes resources for:
+
+- APK build (`build-apk` Job)
+- Unit tests (`run-unit-tests` Job)
+- Android emulator (`emulator` Deployment + Service)
+- APK install to emulator (`install-apk` Job)
+
+> `build-apk`, `run-unit-tests`, and `install-apk` share a `ReadWriteOnce` PVC and should be run sequentially (not at the same time).
+
+## Prerequisites
+
+- A Kubernetes cluster with support for privileged pods
+- A node that exposes `/dev/kvm` (required by the Android emulator)
+- `kubectl` configured for your cluster
+- Docker image for this project built from the existing `Dockerfile`
+
+## 1) Build the app image
+
+From the repository root:
+
+```bash
+docker build -t student-fitness-android:local .
+```
+
+If using a local cluster, load that image into the cluster runtime (example for minikube):
+
+```bash
+minikube image load student-fitness-android:local
+```
+
+## 2) Apply Kubernetes resources
+
+```bash
+kubectl apply -f kubernetes/namespace.yaml
+kubectl apply -f kubernetes/persistent-volume-claims.yaml
+kubectl apply -f kubernetes/emulator.yaml
+```
+
+## 3) Build the APK
+
+```bash
+kubectl apply -f kubernetes/build-job.yaml
+kubectl logs -n student-fitness job/build-apk -f
+```
+
+## 4) Run unit tests
+
+```bash
+kubectl apply -f kubernetes/test-job.yaml
+kubectl logs -n student-fitness job/run-unit-tests -f
+```
+
+## 5) Install APK on the emulator
+
+After the emulator is running and the build job has completed:
+
+```bash
+kubectl apply -f kubernetes/install-job.yaml
+kubectl logs -n student-fitness job/install-apk -f
+```
+
+## Accessing the emulator UI
+
+The emulator service is exposed as `NodePort`. To discover the allocated Web VNC port:
+
+```bash
+kubectl get svc emulator -n student-fitness
+```
+
+Open `http://<node-ip>:<node-port>` for the `6080/TCP` service port.
+
+## Notes
+
+- `build-artifacts-pvc` stores Gradle build outputs and reports shared across Jobs.
+- `build-artifacts-pvc` uses `ReadWriteOnce` for broad storage-class compatibility, so run the Jobs one at a time.
+- `emulator-data-pvc` persists emulator data (`/home/androidusr`) across pod restarts.
+- If you need to re-run Jobs, delete the previous Job resource first:
+
+```bash
+kubectl delete job build-apk run-unit-tests install-apk -n student-fitness
+```

--- a/README.kubernetes.md
+++ b/README.kubernetes.md
@@ -91,6 +91,43 @@ kubectl get svc emulator -n student-fitness
 
 Open `http://<node-ip>:<node-port>` for the `6080/TCP` service port.
 
+## Troubleshooting
+
+### `ERROR: no nodes found for cluster "kind"` (or any cluster name)
+
+This error means no kind cluster is currently running. kind clusters are **ephemeral** — they do not persist across machine reboots or Docker Desktop restarts. You must create the cluster before loading images or deploying resources.
+
+**1. Create a kind cluster**
+
+```bat
+kind create cluster --name kind
+```
+
+Wait ~1–2 minutes for the cluster to be ready.
+
+**2. Verify it is running**
+
+```bat
+kind get clusters
+kubectl cluster-info --context kind-kind
+```
+
+**3. Load your image into the cluster**
+
+```bat
+kind load docker-image student-fitness-android:local --name kind
+```
+
+**4. Continue with deployment**
+
+```bat
+kubectl apply -f kubernetes/
+```
+
+> **Why this happens:** Unlike Docker containers, a kind cluster lives inside Docker containers that are destroyed when Docker Desktop stops or your machine restarts. You need to re-run `kind create cluster` and `kind load docker-image` each time this happens.
+
+---
+
 ## Notes
 
 - `build-artifacts-pvc` stores Gradle build outputs and reports shared across Jobs.

--- a/kubernetes/build-job.yaml
+++ b/kubernetes/build-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: build-apk
+  namespace: student-fitness
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: build
+          image: student-fitness-android:local
+          imagePullPolicy: IfNotPresent
+          command: ["./gradlew", "assembleDebug", "--no-daemon"]
+          volumeMounts:
+            - name: build-artifacts
+              mountPath: /app/app/build
+      volumes:
+        - name: build-artifacts
+          persistentVolumeClaim:
+            claimName: build-artifacts-pvc

--- a/kubernetes/emulator.yaml
+++ b/kubernetes/emulator.yaml
@@ -39,7 +39,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: emulator-data
-              mountPath: /home/androidusr
+              mountPath: /home/androidusr/.android
             - name: kvm
               mountPath: /dev/kvm
       volumes:

--- a/kubernetes/emulator.yaml
+++ b/kubernetes/emulator.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emulator
+  namespace: student-fitness
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emulator
+  template:
+    metadata:
+      labels:
+        app: emulator
+    spec:
+      containers:
+        - name: emulator
+          image: budtmo/docker-android:emulator_14.0
+          env:
+            - name: EMULATOR_DEVICE
+              value: "Nexus 5"
+            - name: WEB_VNC
+              value: "true"
+          ports:
+            - containerPort: 6080
+              name: webvnc
+            - containerPort: 5554
+              name: adb-console
+            - containerPort: 5555
+              name: adb
+          resources:
+            limits:
+              cpu: "4"
+              memory: "4Gi"
+            requests:
+              cpu: "2"
+              memory: "2Gi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: emulator-data
+              mountPath: /home/androidusr
+            - name: kvm
+              mountPath: /dev/kvm
+      volumes:
+        - name: emulator-data
+          persistentVolumeClaim:
+            claimName: emulator-data-pvc
+        - name: kvm
+          hostPath:
+            path: /dev/kvm
+            type: CharDevice
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emulator
+  namespace: student-fitness
+spec:
+  type: NodePort
+  selector:
+    app: emulator
+  ports:
+    - name: webvnc
+      port: 6080
+      targetPort: 6080
+      protocol: TCP
+    - name: adb-console
+      port: 5554
+      targetPort: 5554
+      protocol: TCP
+    - name: adb
+      port: 5555
+      targetPort: 5555
+      protocol: TCP

--- a/kubernetes/install-job.yaml
+++ b/kubernetes/install-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-apk
+  namespace: student-fitness
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: install
+          image: student-fitness-android:local
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "/usr/local/bin/install-apk.sh"]
+          env:
+            - name: EMULATOR_HOST
+              value: emulator
+            - name: EMULATOR_ADB_PORT
+              value: "5555"
+          volumeMounts:
+            - name: build-artifacts
+              mountPath: /app/app/build
+      volumes:
+        - name: build-artifacts
+          persistentVolumeClaim:
+            claimName: build-artifacts-pvc

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: student-fitness

--- a/kubernetes/persistent-volume-claims.yaml
+++ b/kubernetes/persistent-volume-claims.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: emulator-data-pvc
+  namespace: student-fitness
+spec:
+  # Single emulator pod writes this volume.
+  # ReadWriteOnce keeps compatibility with common default storage classes.
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: build-artifacts-pvc
+  namespace: student-fitness
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/test-job.yaml
+++ b/kubernetes/test-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: run-unit-tests
+  namespace: student-fitness
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: test
+          image: student-fitness-android:local
+          imagePullPolicy: IfNotPresent
+          command: ["./gradlew", "test", "--no-daemon"]
+          volumeMounts:
+            - name: build-artifacts
+              mountPath: /app/app/build
+      volumes:
+        - name: build-artifacts
+          persistentVolumeClaim:
+            claimName: build-artifacts-pvc


### PR DESCRIPTION
This pull request introduces a complete Kubernetes-based workflow for building, testing, and running the Student Fitness Android app, mirroring the existing Docker Compose setup. It adds all the necessary Kubernetes resource manifests and a comprehensive setup guide for running builds, tests, and the emulator in a Kubernetes cluster. The workflow uses persistent storage to share build artifacts between jobs and provides instructions for both local (minikube, kind) and remote clusters.

The most important changes are:

**Kubernetes Resource Definitions**

* Added `kubernetes/namespace.yaml` to define a dedicated `student-fitness` namespace for all resources.
* Added `kubernetes/persistent-volume-claims.yaml` to create two PVCs: `build-artifacts-pvc` (for sharing build outputs between jobs) and `emulator-data-pvc` (for persisting emulator AVD data).

**Job and Deployment Manifests**

* Added `kubernetes/build-job.yaml` for building the APK, `kubernetes/test-job.yaml` for running unit tests, and `kubernetes/install-job.yaml` for installing the APK on the emulator. All jobs use the same image and share the `build-artifacts-pvc` for build outputs. [[1]](diffhunk://#diff-65732f2bd2903638af268f646acd0fe375239e8630eade9a1806096c1dd2b3a1R1-R23) [[2]](diffhunk://#diff-e5c2e6d3cf2bfc058d6ff6170a4d96412baf73d76ed4683eb67a02aad11c6558R1-R23) [[3]](diffhunk://#diff-4ca5dade12eab5a63ea752d0b6933682c4624d4bd12d9ea1735249ecb4609218R1-R28)
* Added `kubernetes/emulator.yaml` with a privileged `Deployment` for the Android emulator (using `/dev/kvm` for hardware acceleration) and a `Service` exposing VNC and ADB ports via `NodePort`. Emulator state is persisted via `emulator-data-pvc`.

**Documentation**

* Added a detailed `README.kubernetes.md` with step-by-step instructions for building the image, deploying to Kubernetes (including minikube and kind specifics), running jobs, accessing the emulator UI, and troubleshooting common issues.