### PR TITLE
Remove developer menu shortcuts and cleanup

### DIFF
--- a/app/src/main/java/com/team2/studentfitness/MainActivity.kt
+++ b/app/src/main/java/com/team2/studentfitness/MainActivity.kt
@@ -6,10 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Build
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -18,7 +14,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.team2.studentfitness.ui.navigation.AppRoutes
@@ -53,7 +48,6 @@ class MainActivity : ComponentActivity() {
 
             StudentFitnessTheme(darkTheme = isDarkMode) {
                 val navController = rememberNavController()
-                val currentDestination = navController.currentBackStackEntryAsState().value?.destination?.route
 
                 val securePinManager = remember { SecurePinManager(context) }
                 val loginViewModel = remember { LoginViewModel(securePinManager) }
@@ -67,15 +61,7 @@ class MainActivity : ComponentActivity() {
                 }
 
                 Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    floatingActionButton = {
-                        // Keep dev menu available everywhere for developers
-                        if (currentDestination != AppRoutes.DeveloperMenu) {
-                            FloatingActionButton(onClick = { navController.navigate(AppRoutes.DeveloperMenu) }) {
-                                Icon(imageVector = Icons.Default.Build, contentDescription = "Open developer menu")
-                            }
-                        }
-                    }
+                    modifier = Modifier.fillMaxSize()
                 ) { innerPadding ->
                     NavHost(
                         navController = navController,
@@ -100,8 +86,7 @@ class MainActivity : ComponentActivity() {
                                     navController.navigate(AppRoutes.Dashboard) {
                                         popUpTo(AppRoutes.Login) { inclusive = true }
                                     }
-                                },
-                                onOpenDevMenu = { navController.navigate(AppRoutes.DeveloperMenu) }
+                                }
                             )
                         }
                         composable(AppRoutes.DeveloperMenu) {

--- a/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/team2/studentfitness/ui/screens/LoginScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.team2.studentfitness.ui.theme.LoginBackground
-import com.team2.studentfitness.ui.theme.LoginOrange
 import com.team2.studentfitness.ui.theme.LoginInputBg
 import com.team2.studentfitness.viewmodels.LoginViewModel
 
@@ -28,8 +26,7 @@ import com.team2.studentfitness.viewmodels.LoginViewModel
 fun LoginScreen(
     viewModel: LoginViewModel,
     modifier: Modifier = Modifier,
-    onLoginSuccess: () -> Unit = {},
-    onOpenDevMenu: () -> Unit = {}
+    onLoginSuccess: () -> Unit = {}
 ) {
     var pin by remember { mutableStateOf("") }
     val isPinSet = viewModel.isPinSet()
@@ -38,7 +35,6 @@ fun LoginScreen(
     val isDark = isSystemInDarkTheme()
     val bgColor = MaterialTheme.colorScheme.background
     val accentColor = MaterialTheme.colorScheme.secondary
-    val secondaryTextColor = if (isDark) Color.LightGray else Color.White // Original subtitle was white on teal
 
     Box(
         modifier = modifier
@@ -151,14 +147,6 @@ fun LoginScreen(
                         fontWeight = FontWeight.Bold,
                         fontSize = 16.sp
                     )
-                }
-
-                // Bypass Button (Dev Only)
-                TextButton(
-                    onClick = onOpenDevMenu,
-                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 8.dp)
-                ) {
-                    Text("Open Dev Menu", color = accentColor.copy(alpha = 0.8f), fontSize = 12.sp)
                 }
             }
 


### PR DESCRIPTION
Remove developer-only UI and related code paths: delete the floating action button in MainActivity that opened the Developer Menu and the in-screen "Open Dev Menu" button in LoginScreen. Clean up unused imports and variables (Icons, Build, FloatingActionButton, Icon, currentBackStackEntryAsState, LoginBackground/LoginOrange, secondaryTextColor) and update the LoginScreen API by removing the onOpenDevMenu parameter. Adjust call sites to match the simplified signature.